### PR TITLE
[Merged by Bors] - Automatic openapi spec generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ install:
   - cargo test --no-run --color always --all --all-features
 
 script:
-  - RUST_BACKTRACE=full cargo test --color always --all --all-features
   - RUST_BACKTRACE=full cargo test --color always --all
+  - RUST_BACKTRACE=full cargo test --color always --all --all-features
 
 #before_deploy:
 #  - CARGO_TARGET_DIR=$HOME/cargo-target cargo doc --color always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "0.2", features = ["macros"] }
 warp = "0.2"
 http = "0.2"
 serde = { version = "1", features = ["derive"] }
-rweb-openapi = { version = "0.3.0", optional = true }
+rweb-openapi = { version = "0.3.1", optional = true }
 scoped-tls = "1"
 futures = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "0.2", features = ["macros"] }
 warp = "0.2"
 http = "0.2"
 serde = { version = "1", features = ["derive"] }
-rweb-openapi = { version = "0.2.1", optional = true }
+rweb-openapi = { version = "0.3.0", optional = true }
 scoped-tls = "1"
 futures = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ openapi = ["rweb-macros/openapi", "rweb-openapi"]
 [dependencies]
 rweb-macros = { version = "0.3.0-alpha.0", path = "./macros" }
 tokio = { version = "0.2", features = ["macros"] }
-warp = "0.2"
+warp = "0.2.1"
 http = "0.2"
 serde = { version = "1", features = ["derive"] }
 rweb-openapi = { version = "0.3.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tls = ["warp/rustls"]
 openapi = ["rweb-macros/openapi", "rweb-openapi"]
 
 [dependencies]
-rweb-macros = { version = "0.3.0-alpha.0", path = "./macros" }
+rweb-macros = { version = "0.3.0-alpha.1", path = "./macros" }
 tokio = { version = "0.2", features = ["macros"] }
 warp = "0.2.1"
 http = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ license = "Apache-2.0"
 repository = "https://github.com/kdy1/rweb.git"
 description = "Yet another web server framework for rust"
 edition = "2018"
+keywords = ["rweb", "server", "http", "hyper"]
+autotests = true
+autoexamples = true
 
 [features]
 default = ["multipart", "websocket"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ http = "0.2"
 hyper = "0.13"
 pretty_env_logger = "0.3"
 log = "0.4"
+serde_yaml = "0.8"
 
 [[example]]
 name = "openapi"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,23 @@
 
 Yet another web server framework for rust.
 
-Installation:
+Installation (without automatic openapi generation):
 ```toml
 [dependencies]
-rweb = "0.3.0-alpha.0"
+rweb = "0.3.0-alpha.1"
 ```
+
+
+
+# Features
+
+ - Safe & Correct
+
+Since `rweb` is based on [warp][], which features safety and correctness, `rweb` has same property.  
+
+
+ - Automatic openapi spec generation
+
+
+
+[warp]:https://github.com/seanmonstar/warp

--- a/examples/futures.rs
+++ b/examples/futures.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 
-use rweb::get;
+use rweb::*;
 use std::{convert::Infallible, str::FromStr, time::Duration};
 
 #[tokio::main]
@@ -18,6 +18,7 @@ async fn sleepy(seconds: Seconds) -> Result<impl rweb::Reply, Infallible> {
 }
 
 /// A newtype to enforce our maximum allowed seconds.
+#[cfg_attr(feature = "openapi", derive(Schema))]
 struct Seconds(u64);
 
 impl FromStr for Seconds {

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -9,7 +9,7 @@ async fn main() {
         math::math()
             .or(products::products())
             .or(generic::body())
-            .or(generic::option())
+            .or(generic::optional())
     });
 
     println!("{}", to_yaml(&OpenApi::V3_0(spec)).unwrap());
@@ -80,8 +80,8 @@ mod generic {
         String::new()
     }
 
-    #[post("/option")]
-    pub fn option(_: Option<Json<LoginForm>>) -> String {
+    #[post("/optional")]
+    pub fn optional(_: Option<Json<LoginForm>>) -> String {
         String::new()
     }
 

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -25,8 +25,12 @@ async fn main() {
 }
 
 mod response {
-    use rweb::*;
+    use rweb::{
+        openapi::{Entity, Schema},
+        *,
+    };
     use serde::Serialize;
+    use std::collections::BTreeMap;
 
     #[router("/response", services(json))]
     pub fn response() {}
@@ -34,6 +38,21 @@ mod response {
     #[derive(Debug, Serialize)]
     pub struct Data {
         msg: String,
+    }
+
+    /// TODO: Replace this with derive
+    impl Entity for Data {
+        fn describe() -> Schema {
+            let mut map = BTreeMap::new();
+
+            map.insert("msg".into(), String::describe());
+
+            Schema {
+                schema_type: "object".into(),
+                properties: map,
+                ..Default::default()
+            }
+        }
     }
 
     #[get("/json")]
@@ -62,13 +81,33 @@ mod math {
 
 mod products {
     use super::SearchReq;
-    use rweb::*;
+    use rweb::{
+        openapi::{Entity, Schema},
+        *,
+    };
     use serde::{Deserialize, Serialize};
+    use std::collections::BTreeMap;
 
     #[derive(Debug, Default, Serialize, Deserialize)]
     pub struct Product {
         pub id: String,
         pub title: String,
+    }
+
+    /// TODO: Replace this with derive
+    impl Entity for Product {
+        fn describe() -> Schema {
+            let mut map = BTreeMap::new();
+
+            map.insert("id".into(), String::describe());
+            map.insert("title".into(), String::describe());
+
+            Schema {
+                schema_type: "object".into(),
+                properties: map,
+                ..Default::default()
+            }
+        }
     }
 
     #[router("/products", services(list, product))]

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -120,6 +120,7 @@ mod generic {
     }
 
     #[post("/login")]
+    #[openapi(tags("auth"))]
     pub fn body(_: Json<LoginForm>) -> String {
         String::new()
     }

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -2,7 +2,6 @@ use rweb::{
     openapi::{Entity, Schema},
     *,
 };
-use rweb_openapi::{to_yaml, OpenApi};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
@@ -19,7 +18,7 @@ async fn main() {
             .or(response::response())
     });
 
-    println!("{}", to_yaml(&OpenApi::V3_0(spec)).unwrap());
+    println!("{}", serde_yaml::to_string(&spec).unwrap());
 
     panic!();
 }

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -1,9 +1,5 @@
-use rweb::{
-    openapi::{Entity, Schema},
-    *,
-};
+use rweb::*;
 use serde::Deserialize;
-use std::collections::BTreeMap;
 
 #[tokio::main]
 async fn main() {
@@ -24,34 +20,15 @@ async fn main() {
 }
 
 mod response {
-    use rweb::{
-        openapi::{Entity, Schema},
-        *,
-    };
+    use rweb::*;
     use serde::Serialize;
-    use std::collections::BTreeMap;
 
     #[router("/response", services(json))]
     pub fn response() {}
 
-    #[derive(Debug, Serialize)]
+    #[derive(Debug, Serialize, Schema)]
     pub struct Data {
         msg: String,
-    }
-
-    /// TODO: Replace this with derive
-    impl Entity for Data {
-        fn describe() -> Schema {
-            let mut map = BTreeMap::new();
-
-            map.insert("msg".into(), String::describe());
-
-            Schema {
-                schema_type: "object".into(),
-                properties: map,
-                ..Default::default()
-            }
-        }
     }
 
     #[get("/json")]
@@ -80,33 +57,13 @@ mod math {
 
 mod products {
     use super::SearchReq;
-    use rweb::{
-        openapi::{Entity, Schema},
-        *,
-    };
+    use rweb::*;
     use serde::{Deserialize, Serialize};
-    use std::collections::BTreeMap;
 
-    #[derive(Debug, Default, Serialize, Deserialize)]
+    #[derive(Debug, Default, Serialize, Deserialize, Schema)]
     pub struct Product {
         pub id: String,
         pub title: String,
-    }
-
-    /// TODO: Replace this with derive
-    impl Entity for Product {
-        fn describe() -> Schema {
-            let mut map = BTreeMap::new();
-
-            map.insert("id".into(), String::describe());
-            map.insert("title".into(), String::describe());
-
-            Schema {
-                schema_type: "object".into(),
-                properties: map,
-                ..Default::default()
-            }
-        }
     }
 
     #[router("/products", services(list, product))]
@@ -133,51 +90,19 @@ mod products {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Schema)]
 struct SearchReq {
     query: String,
 }
 
-/// TODO: Replace this with derive
-impl Entity for SearchReq {
-    fn describe() -> Schema {
-        let mut map = BTreeMap::new();
-
-        map.insert("query".into(), String::describe());
-
-        Schema {
-            schema_type: "object".into(),
-            properties: map,
-            ..Default::default()
-        }
-    }
-}
-
 mod generic {
     use super::SearchReq;
-    use rweb::{openapi::Entity, *};
-    use rweb_openapi::v3_0::Schema;
+    use rweb::*;
     use serde::Deserialize;
-    use std::collections::BTreeMap;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Schema)]
     struct LoginForm {
         id: String,
-    }
-
-    /// TODO: Replace this with derive
-    impl Entity for LoginForm {
-        fn describe() -> Schema {
-            let mut map = BTreeMap::new();
-
-            map.insert("id".into(), String::describe());
-
-            Schema {
-                schema_type: "object".into(),
-                properties: map,
-                ..Default::default()
-            }
-        }
     }
 
     #[post("/login")]

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -52,6 +52,8 @@ mod math {
     pub fn math() {}
 
     /// Adds a and b
+    /// and
+    /// return it
     #[get("/sum/{a}/{b}")]
     fn sum(a: usize, b: usize) -> String {
         (a + b).to_string()

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -32,7 +32,7 @@ mod response {
     pub fn response() {}
 
     #[derive(Debug, Serialize)]
-    struct Data {
+    pub struct Data {
         msg: String,
     }
 

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -1,5 +1,10 @@
-use rweb::*;
+use rweb::{
+    openapi::{Entity, Schema},
+    *,
+};
 use rweb_openapi::{to_yaml, OpenApi};
+use serde::Deserialize;
+use std::collections::BTreeMap;
 
 #[tokio::main]
 async fn main() {
@@ -33,6 +38,7 @@ mod math {
 }
 
 mod products {
+    use super::SearchReq;
     use rweb::*;
     use serde::{Deserialize, Serialize};
 
@@ -49,7 +55,8 @@ mod products {
     #[get("/")]
     #[openapi(id = "products.list")]
     #[openapi(summary = "List products")]
-    fn list() -> Json<Vec<Product>> {
+    fn list(_query: Query<SearchReq>) -> Json<Vec<Product>> {
+        // Mix
         vec![].into()
     }
 
@@ -65,7 +72,28 @@ mod products {
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct SearchReq {
+    query: String,
+}
+
+/// TODO: Replace this with derive
+impl Entity for SearchReq {
+    fn describe() -> Schema {
+        let mut map = BTreeMap::new();
+
+        map.insert("query".into(), String::describe());
+
+        Schema {
+            schema_type: "object".into(),
+            properties: map,
+            ..Default::default()
+        }
+    }
+}
+
 mod generic {
+    use super::SearchReq;
     use rweb::{openapi::Entity, *};
     use rweb_openapi::v3_0::Schema;
     use serde::Deserialize;
@@ -99,26 +127,6 @@ mod generic {
     #[post("/optional")]
     pub fn optional(_: Option<Json<LoginForm>>) -> String {
         String::new()
-    }
-
-    #[derive(Debug, Deserialize)]
-    struct SearchReq {
-        query: String,
-    }
-
-    /// TODO: Replace this with derive
-    impl Entity for SearchReq {
-        fn describe() -> Schema {
-            let mut map = BTreeMap::new();
-
-            map.insert("query".into(), String::describe());
-
-            Schema {
-                schema_type: "object".into(),
-                properties: map,
-                ..Default::default()
-            }
-        }
     }
 
     #[post("/search")]

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -10,6 +10,7 @@ async fn main() {
             .or(products::products())
             .or(generic::body())
             .or(generic::optional())
+            .or(generic::search())
     });
 
     println!("{}", to_yaml(&OpenApi::V3_0(spec)).unwrap());
@@ -75,16 +76,7 @@ mod generic {
         id: String,
     }
 
-    #[post("/login")]
-    pub fn body(_: Json<LoginForm>) -> String {
-        String::new()
-    }
-
-    #[post("/optional")]
-    pub fn optional(_: Option<Json<LoginForm>>) -> String {
-        String::new()
-    }
-
+    /// TODO: Replace this with derive
     impl Entity for LoginForm {
         fn describe() -> Schema {
             let mut map = BTreeMap::new();
@@ -97,5 +89,40 @@ mod generic {
                 ..Default::default()
             }
         }
+    }
+
+    #[post("/login")]
+    pub fn body(_: Json<LoginForm>) -> String {
+        String::new()
+    }
+
+    #[post("/optional")]
+    pub fn optional(_: Option<Json<LoginForm>>) -> String {
+        String::new()
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct SearchReq {
+        query: String,
+    }
+
+    /// TODO: Replace this with derive
+    impl Entity for SearchReq {
+        fn describe() -> Schema {
+            let mut map = BTreeMap::new();
+
+            map.insert("query".into(), String::describe());
+
+            Schema {
+                schema_type: "object".into(),
+                properties: map,
+                ..Default::default()
+            }
+        }
+    }
+
+    #[post("/search")]
+    pub fn search(_: Option<Query<SearchReq>>) -> String {
+        String::new()
     }
 }

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -16,11 +16,32 @@ async fn main() {
             .or(generic::body())
             .or(generic::optional())
             .or(generic::search())
+            .or(response::response())
     });
 
     println!("{}", to_yaml(&OpenApi::V3_0(spec)).unwrap());
 
     panic!();
+}
+
+mod response {
+    use rweb::*;
+    use serde::Serialize;
+
+    #[router("/response", services(json))]
+    pub fn response() {}
+
+    #[derive(Debug, Serialize)]
+    struct Data {
+        msg: String,
+    }
+
+    #[get("/json")]
+    pub fn json() -> Json<Data> {
+        Json::from(Data {
+            msg: "Hello".into(),
+        })
+    }
 }
 
 mod math {

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 #[tokio::main]
 async fn main() {
-    let (spec, filter) = openapi::spec(|| {
+    let (spec, filter) = openapi::spec().build(|| {
         // Build filters
 
         math::math()

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 #[tokio::main]
 async fn main() {
-    let (spec, filter) = openapi::spec().build(|| {
+    let (spec, _filter) = openapi::spec().build(|| {
         // Build filters
 
         math::math()
@@ -15,8 +15,6 @@ async fn main() {
     });
 
     println!("{}", serde_yaml::to_string(&spec).unwrap());
-
-    panic!();
 }
 
 mod response {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,3 +18,4 @@ rweb-openapi = "0.3.0"
 pmutil = "0.5.3"
 syn = { version = "1", features = ["full"] }
 proc-macro2 = "1"
+quote = "1"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 openapi = []
 
 [dependencies]
-rweb-openapi = "0.3.0"
+rweb-openapi = "0.3.1"
 pmutil = "0.5.3"
 syn = { version = "1", features = ["full"] }
 proc-macro2 = "1"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 openapi = []
 
 [dependencies]
-rweb-openapi = "0.2.1"
+rweb-openapi = "0.3.0"
 pmutil = "0.5.3"
 syn = { version = "1", features = ["full"] }
 proc-macro2 = "1"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,6 +16,6 @@ openapi = []
 [dependencies]
 rweb-openapi = "0.3.1"
 pmutil = "0.5.3"
-syn = { version = "1", features = ["full"] }
+syn = { version = "1", features = ["full", "visit"] }
 proc-macro2 = "1"
 quote = "1"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -78,7 +78,7 @@ pub fn router(
     router::router(attr.into(), item.into()).dump().into()
 }
 
-#[proc_macro_derive(Schema)]
+#[proc_macro_derive(Schema, attributes(schema))]
 pub fn derive_schema(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = syn::parse::<syn::DeriveInput>(input).expect("failed to parse derive input");
     openapi::derive_schema(input).into()

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -77,3 +77,9 @@ pub fn router(
 ) -> proc_macro::TokenStream {
     router::router(attr.into(), item.into()).dump().into()
 }
+
+#[proc_macro_derive(Schema)]
+pub fn derive_schema(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = syn::parse::<syn::DeriveInput>(input).expect("failed to parse derive input");
+    openapi::derive_schema(input).into()
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,6 +7,7 @@ mod parse;
 mod path;
 mod route;
 mod router;
+mod util;
 
 #[proc_macro_attribute]
 pub fn get(

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -486,6 +486,7 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
                         }
                         _ => panic!("Correct usage: #[openapi(tags(\"foo\" ,\"bar\")]"),
                     }
+                } else if config.path().is_ident("response") {
                 } else {
                     panic!("Unknown openapi config `{}`", config.dump())
                 }

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -486,7 +486,6 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
                         }
                         _ => panic!("Correct usage: #[openapi(tags(\"foo\" ,\"bar\")]"),
                     }
-                } else if config.path().is_ident("response") {
                 } else {
                     panic!("Unknown openapi config `{}`", config.dump())
                 }

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -194,6 +194,9 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
 
         if attr.path.is_ident("doc") {
             let s: EqStr = parse2(attr.tokens.clone()).expect("failed to parse comments");
+            if !op.description.is_empty() {
+                op.description.push(' ');
+            }
             op.description.push_str(&s.value.value().trim_start());
             // Preserve comments
             return true;

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -12,7 +12,7 @@ use crate::{
     util::ItemImplExt,
 };
 use pmutil::{q, Quote, ToTokensExt};
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use rweb_openapi::v3_0::{Location, ObjectOrReference, Operation, Parameter, Schema};
 use std::borrow::Cow;
 use syn::{
@@ -30,8 +30,8 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
 
         attrs.retain(|attr| {
             if attr.path.is_ident("schema") {
-                let v = match parse2::<Paren<KeyValue>>(attr.tokens.clone()) {
-                    Ok(v) if v.inner.key.value() == "description" => v.inner.value.value(),
+                let v = match parse2::<Paren<KeyValue<Ident>>>(attr.tokens.clone()) {
+                    Ok(v) if v.inner.key == "description" => v.inner.value.value(),
                     _ => return true,
                 };
                 doc = Some(v);

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -25,7 +25,12 @@ pub fn quote_op(op: Operation) -> Expr {
     let tags_v: Punctuated<Quote, Token![,]> = op
         .tags
         .iter()
-        .map(|tag| Pair::Punctuated(q!(Vars { tag }, { tag.to_string() }), Default::default()))
+        .map(|tag| {
+            Pair::Punctuated(
+                q!(Vars { tag }, { rweb::rt::Cow::Borrowed(tag) }),
+                Default::default(),
+            )
+        })
         .collect();
 
     let params_v: Punctuated<Expr, Token![,]> = op
@@ -45,16 +50,11 @@ pub fn quote_op(op: Operation) -> Expr {
         {
             rweb::openapi::Operation {
                 tags: vec![tags_v],
-                summary: summary_v.to_string(),
-                description: description_v.to_string(),
-                external_docs: Default::default(),
-                operation_id: id_v.to_string(),
+                summary: rweb::rt::Cow::Borrowed(summary_v),
+                description: rweb::rt::Cow::Borrowed(description_v),
+                operation_id: rweb::rt::Cow::Borrowed(id_v),
                 parameters: vec![params_v],
-                request_body: Default::default(),
-                responses: Default::default(),
-                callbacks: Default::default(),
-                deprecated: Default::default(),
-                servers: Default::default(),
+                ..Default::default()
             }
         }
     )
@@ -101,8 +101,8 @@ fn quote_parameter(param: &ObjectOrReference<Parameter>) -> Expr {
         },
         {
             rweb::openapi::ObjectOrReference::Object(rweb::openapi::Parameter {
-                name: name_v.to_string(),
-                location: location_v.to_string(),
+                name: rweb::rt::Cow::Borrowed(name_v),
+                location: location_v,
                 required: required_v,
                 schema: Some(<Type as rweb::openapi::Entity>::describe()),
                 ..Default::default()

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -18,8 +18,21 @@ use syn::{
     export::ToTokens,
     parse2,
     punctuated::{Pair, Punctuated},
-    Attribute, Expr, Lit, Meta, NestedMeta, Signature, Token,
+    Attribute, DeriveInput, Expr, ItemImpl, Lit, Meta, NestedMeta, Signature, Token,
 };
+
+pub fn derive_schema(input: DeriveInput) -> TokenStream {
+    let item = q!(Vars { Type: &input.ident }, {
+        impl rweb::openapi::Entity for Type {
+            fn describe() -> rweb::openapi::Schema {
+                body
+            }
+        }
+    })
+    .parse::<ItemImpl>();
+
+    item.dump()
+}
 
 pub fn quote_op(op: Operation) -> Expr {
     let tags_v: Punctuated<Quote, Token![,]> = op

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -169,8 +169,6 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
                     let desc = extract_doc(&mut v.attrs);
 
                     match v.fields {
-                        Fields::Named(ref f) if f.named.len() == 1 => None,
-
                         Fields::Named(..) => Some(Pair::Punctuated(
                             {
                                 let fields = handle_fields(&mut v.fields);
@@ -179,7 +177,7 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
                                     ({
                                         #[allow(unused_mut)]
                                         let mut s = rweb::openapi::Schema {
-                                            fields,
+                                            properties: fields,
                                             ..rweb::rt::Default::default()
                                         };
                                         let description = desc;

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -175,9 +175,12 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
         Data::Union(_) => unimplemented!("#[derive(Schema)] for union"),
     }
 
+    let desc = extract_doc(&mut input.attrs);
+
     let mut item = q!(
         Vars {
             Type: &input.ident,
+            desc,
             fields
         },
         {
@@ -185,6 +188,7 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
                 fn describe() -> rweb::openapi::Schema {
                     rweb::openapi::Schema {
                         fields,
+                        description: rweb::rt::Cow::Borrowed(desc),
                         ..rweb::rt::Default::default()
                     }
                 }

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -68,7 +68,9 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
 
             fields.push(q!({ schema_type: rweb::openapi::Type::Object }).parse());
         }
-        Data::Enum(_) => unimplemented!("#[derive(Schema)] for enum"),
+        Data::Enum(ref data) => {
+            fields.push(q!(Vars {}, { one_of: vec![] }).parse());
+        }
         Data::Union(_) => unimplemented!("#[derive(Schema)] for union"),
     }
 

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -150,9 +150,13 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
 
     match input.data {
         Data::Struct(ref mut data) => {
-            {
-                let block = handle_fields(&mut data.fields);
-                fields.push(q!(Vars { block }, { properties: block }).parse());
+            match data.fields {
+                Fields::Named(_) => {
+                    let block = handle_fields(&mut data.fields);
+                    fields.push(q!(Vars { block }, { properties: block }).parse());
+                }
+                Fields::Unnamed(ref n) if n.unnamed.len() == 1 => {}
+                _ => {}
             }
 
             fields.push(q!({ schema_type: rweb::openapi::Type::Object }).parse());

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -229,10 +229,13 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
     }
 
     let mut item = if let Some(comp) = component {
+        let path_to_schema = format!("#/components/schemas/{}", comp);
+
         q!(
             Vars {
                 Type: &input.ident,
                 desc,
+                path_to_schema,
                 fields,
                 comp,
             },
@@ -240,6 +243,7 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
                 impl rweb::openapi::Entity for Type {
                     fn describe() -> rweb::openapi::Schema {
                         rweb::openapi::Schema {
+                            ref_path: rweb::rt::Cow::Borrowed(path_to_schema),
                             ..rweb::rt::Default::default()
                         }
                     }

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -8,6 +8,7 @@
 use crate::{
     parse::{Delimited, Paren},
     path::find_ty,
+    route::EqStr,
 };
 use pmutil::{q, Quote, ToTokensExt};
 use proc_macro2::TokenStream;
@@ -191,7 +192,12 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
             return false;
         }
 
-        if attr.path.is_ident("doc") {}
+        if attr.path.is_ident("doc") {
+            let s: EqStr = parse2(attr.tokens.clone()).expect("failed to parse comments");
+            op.description.push_str(&s.value.value().trim_start());
+            // Preserve comments
+            return true;
+        }
 
         true
     });

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -34,8 +34,8 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
                     Ok(v) if v.inner.key.value() == "description" => v.inner.value.value(),
                     _ => return true,
                 };
-
                 doc = Some(v);
+                return false;
             }
 
             if attr.path.is_ident("doc") {
@@ -46,8 +46,8 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
 
                 if !comments.is_empty() {
                     comments.push(' ');
-                    comments.push_str(&v.value())
                 }
+                comments.push_str(&v.value());
             }
 
             true
@@ -63,7 +63,6 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
         let i = f.ident.as_ref().unwrap();
 
         let desc = extract_doc(&mut f.attrs);
-
         q!(
             Vars {
                 name: i,
@@ -75,7 +74,10 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
                     {
                         #[allow(unused_mut)]
                         let mut s = <Type as rweb::openapi::Entity>::describe();
-                        s.description = rweb::rt::Cow::Borrowed(desc);
+                        let description = desc;
+                        if !description.is_empty() {
+                            s.description = rweb::rt::Cow::Borrowed(description);
+                        }
                         s
                     }
                 });

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -9,6 +9,7 @@ use crate::{
     parse::{Delimited, Paren},
     path::find_ty,
     route::EqStr,
+    util::ItemImplExt,
 };
 use pmutil::{q, Quote, ToTokensExt};
 use proc_macro2::TokenStream;
@@ -87,7 +88,8 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
             }
         }
     )
-    .parse::<ItemImpl>();
+    .parse::<ItemImpl>()
+    .with_generics(input.generics.clone());
 
     item.dump()
 }

--- a/macros/src/openapi.rs
+++ b/macros/src/openapi.rs
@@ -248,17 +248,15 @@ pub fn derive_schema(mut input: DeriveInput) -> TokenStream {
                         }
                     }
 
-                    fn describe_component(
-                    ) -> Option<(rweb::rt::Cow<'static, str>, rweb::openapi::Schema)>
-                    {
-                        Some((
+                    fn describe_components() -> rweb::openapi::Components {
+                        vec![(
                             rweb::rt::Cow::Borrowed(comp),
                             rweb::openapi::Schema {
                                 fields,
                                 description: rweb::rt::Cow::Borrowed(desc),
                                 ..rweb::rt::Default::default()
                             },
-                        ))
+                        )]
                     }
                 }
             }

--- a/macros/src/parse.rs
+++ b/macros/src/parse.rs
@@ -5,13 +5,17 @@ use syn::{
     LitStr, Token,
 };
 
-pub(crate) struct KeyValue {
-    pub key: LitStr,
+pub(crate) struct KeyValue<K = LitStr, V = LitStr> {
+    pub key: K,
     _eq: Token![=],
-    pub value: LitStr,
+    pub value: V,
 }
 
-impl Parse for KeyValue {
+impl<K, V> Parse for KeyValue<K, V>
+where
+    K: Parse,
+    V: Parse,
+{
     fn parse(input: ParseStream) -> syn::parse::Result<Self> {
         Ok(KeyValue {
             key: input.parse()?,

--- a/macros/src/parse.rs
+++ b/macros/src/parse.rs
@@ -2,8 +2,24 @@ use syn::{
     parenthesized,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
-    Token,
+    LitStr, Token,
 };
+
+pub(crate) struct KeyValue {
+    pub key: LitStr,
+    _eq: Token![=],
+    pub value: LitStr,
+}
+
+impl Parse for KeyValue {
+    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
+        Ok(KeyValue {
+            key: input.parse()?,
+            _eq: input.parse()?,
+            value: input.parse()?,
+        })
+    }
+}
 
 /// A node wrapped with paren.
 pub(crate) struct Paren<T> {

--- a/macros/src/route/mod.rs
+++ b/macros/src/route/mod.rs
@@ -12,22 +12,22 @@ pub mod fn_attr;
 pub mod param;
 
 /// An eq token followed by literal string
-struct EqStr {
+pub(crate) struct EqStr {
     _eq: Token![=],
-    path: LitStr,
+    pub value: LitStr,
 }
 
 impl Parse for EqStr {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         Ok(EqStr {
             _eq: input.parse()?,
-            path: input.parse()?,
+            value: input.parse()?,
         })
     }
 }
 
 /// An eq token followed by literal string
-struct ParenTwoValue {
+pub(crate) struct ParenTwoValue {
     key: LitStr,
     _eq: Token![,],
     value: LitStr,

--- a/macros/src/route/mod.rs
+++ b/macros/src/route/mod.rs
@@ -136,7 +136,7 @@ pub fn compile_route(
                     Type: &from_req,
                     op
                 },
-                { rweb::openapi::Collector::add_type_to::<Type>(op) }
+                { rweb::openapi::Collector::add_request_type_to::<Type>(op) }
             )
             .parse();
         }

--- a/macros/src/route/param.rs
+++ b/macros/src/route/param.rs
@@ -97,7 +97,7 @@ pub fn compile(
                             expr = q!(
                                 Vars {
                                     expr,
-                                    cookie_name: cookie_name.path
+                                    cookie_name: cookie_name.value
                                 },
                                 { expr.and(rweb::filters::cookie::cookie(cookie_name)) }
                             )
@@ -110,7 +110,7 @@ pub fn compile(
                             expr = q!(
                                 Vars {
                                     expr,
-                                    header_name: header_name.path
+                                    header_name: header_name.value
                                 },
                                 { expr.and(rweb::filters::header::header(header_name)) }
                             )
@@ -124,7 +124,7 @@ pub fn compile(
                         }
                     } else if attr.path.is_ident("filter") {
                         let filter_path: EqStr = parse(attr.tokens.clone());
-                        let filter_path = filter_path.path.value();
+                        let filter_path = filter_path.value.value();
                         let tts: TokenStream = filter_path.parse().expect("failed tokenize");
                         let filter_path: Path = parse(tts);
 

--- a/macros/src/util.rs
+++ b/macros/src/util.rs
@@ -1,0 +1,121 @@
+use pmutil::{synom_ext::FromSpan, ToTokensExt};
+use proc_macro2::Span;
+use quote::quote;
+use syn::{punctuated::Pair, *};
+
+pub fn call_site<T: FromSpan>() -> T {
+    T::from_span(Span::call_site())
+}
+
+/// Extension trait for `ItemImpl` (impl block).
+pub trait ItemImplExt {
+    /// Instead of
+    ///
+    /// ```rust,ignore
+    /// let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    ///
+    /// let item: Item = Quote::new(def_site::<Span>())
+    ///     .quote_with(smart_quote!(
+    /// Vars {
+    /// Type: type_name,
+    /// impl_generics,
+    /// ty_generics,
+    /// where_clause,
+    /// },
+    /// {
+    /// impl impl_generics ::swc_common::AstNode for Type ty_generics
+    /// where_clause {}
+    /// }
+    /// )).parse();
+    /// ```
+    ///
+    /// You can use this like
+    ///
+    /// ```rust,ignore
+    // let item = Quote::new(def_site::<Span>())
+    ///     .quote_with(smart_quote!(Vars { Type: type_name }, {
+    ///         impl ::swc_common::AstNode for Type {}
+    ///     }))
+    ///     .parse::<ItemImpl>()
+    ///     .with_generics(input.generics);
+    /// ```
+    fn with_generics(self, generics: Generics) -> Self;
+}
+
+impl ItemImplExt for ItemImpl {
+    fn with_generics(mut self, mut generics: Generics) -> Self {
+        // TODO: Check conflicting name
+
+        let need_new_punct = !generics.params.empty_or_trailing();
+        if need_new_punct {
+            generics.params.push_punct(call_site());
+        }
+
+        // Respan
+        if let Some(t) = generics.lt_token {
+            self.generics.lt_token = Some(t)
+        }
+        if let Some(t) = generics.gt_token {
+            self.generics.gt_token = Some(t)
+        }
+
+        let ty = self.self_ty;
+
+        // Handle generics defined on struct, enum, or union.
+        let mut item: ItemImpl = {
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+            let item = if let Some((ref polarity, ref path, ref for_token)) = self.trait_ {
+                quote! {
+                    impl #impl_generics #polarity #path #for_token #ty #ty_generics #where_clause {}
+                }
+            } else {
+                quote! {
+                    impl #impl_generics #ty #ty_generics #where_clause {}
+
+                }
+            };
+            parse(item.dump().into())
+                .unwrap_or_else(|err| panic!("with_generics failed: {}\n{}", err, item.dump()))
+        };
+
+        // Handle generics added by proc-macro.
+        item.generics
+            .params
+            .extend(self.generics.params.into_pairs());
+        match self.generics.where_clause {
+            Some(WhereClause {
+                ref mut predicates, ..
+            }) => predicates.extend(
+                generics
+                    .where_clause
+                    .into_iter()
+                    .flat_map(|wc| wc.predicates.into_pairs()),
+            ),
+            ref mut opt @ None => *opt = generics.where_clause,
+        }
+
+        ItemImpl {
+            attrs: self.attrs,
+            defaultness: self.defaultness,
+            unsafety: self.unsafety,
+            impl_token: self.impl_token,
+            brace_token: self.brace_token,
+            items: self.items,
+            ..item
+        }
+    }
+}
+
+pub trait PairExt<T, P>: Sized + Into<Pair<T, P>> {
+    fn map_item<F, NewItem>(self, op: F) -> Pair<NewItem, P>
+    where
+        F: FnOnce(T) -> NewItem,
+    {
+        match self.into() {
+            Pair::Punctuated(t, p) => Pair::Punctuated(op(t), p),
+            Pair::End(t) => Pair::End(op(t)),
+        }
+    }
+}
+
+impl<T, P> PairExt<T, P> for Pair<T, P> {}

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -72,7 +72,7 @@ impl<T> Json<T> {
 }
 
 impl<T> From<T> for Json<T> {
-    #[inline(always)]
+    #[inline]
     fn from(v: T) -> Self {
         Json(v)
     }

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -41,8 +41,16 @@ where
 {
     type Filter = BoxedFilter<(Option<T>,)>;
 
+    fn is_body() -> bool {
+        T::is_body()
+    }
+
     fn is_optional() -> bool {
         true
+    }
+
+    fn is_query() -> bool {
+        T::is_query()
     }
 
     fn new() -> Self::Filter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,8 @@
 //!    }
 //! }
 //!
+//!
+//! #[cfg_attr(feature = "openapi", derive(Schema))]
 //! struct User {
 //!    id: String,
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,7 +362,7 @@
 //! ```
 
 pub use self::factory::{Form, FromRequest, Json, Query};
-pub use rweb_macros::{delete, get, head, options, patch, post, put, router};
+pub use rweb_macros::{delete, get, head, options, patch, post, put, router, Schema};
 pub use warp::{self, *};
 
 mod factory;

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,6 +1,6 @@
 //! Automatic openapi spec generator.
 
-use crate::{FromRequest, Json};
+use crate::{Form, FromRequest, Json, Query};
 use http::Method;
 pub use rweb_openapi::v3_0::*;
 use scoped_tls::scoped_thread_local;
@@ -40,6 +40,26 @@ where
 }
 
 impl<T> Entity for Json<T>
+where
+    T: Entity,
+{
+    #[inline]
+    fn describe() -> Schema {
+        T::describe()
+    }
+}
+
+impl<T> Entity for Query<T>
+where
+    T: Entity,
+{
+    #[inline]
+    fn describe() -> Schema {
+        T::describe()
+    }
+}
+
+impl<T> Entity for Form<T>
 where
     T: Entity,
 {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -114,6 +114,7 @@ pub struct Collector {
 }
 
 impl Collector {
+    /// Method used by `#[router]`.
     #[doc(hidden)]
     pub fn with_appended_prefix<F, Ret>(&mut self, prefix: &str, tags: Vec<&str>, op: F) -> Ret
     where

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -136,7 +136,7 @@ impl Collector {
         ret
     }
 
-    pub fn add_type_to<T: FromRequest + Entity>(mut op: Operation) -> Operation {
+    pub fn add_request_type_to<T: FromRequest + Entity>(mut op: Operation) -> Operation {
         if T::is_body() {
             if op.request_body.is_some() {
                 panic!("Multiple body detected");

--- a/src/openapi/builder.rs
+++ b/src/openapi/builder.rs
@@ -7,13 +7,13 @@ pub struct Builder {
 }
 
 /// Crates a new specification builder
-#[inline(always)]
+#[inline]
 pub fn spec() -> Builder {
     Builder::default()
 }
 
 impl Builder {
-    #[inline(always)]
+    #[inline]
     pub fn info(mut self, info: Info) -> Self {
         self.spec.info = info;
         self

--- a/src/openapi/builder.rs
+++ b/src/openapi/builder.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+/// Builder for openapi v3 specification.
+#[derive(Debug, Clone, Default)]
+pub struct Builder {
+    spec: Spec,
+}
+
+/// Crates a new specification builder
+#[inline(always)]
+pub fn spec() -> Builder {
+    Builder::default()
+}
+
+impl Builder {
+    #[inline(always)]
+    pub fn info(mut self, info: Info) -> Self {
+        self.spec.info = info;
+        self
+    }
+
+    /// Creates an openapi specification. You can serialize this as json or yaml
+    /// to generate client codes.
+    pub fn build<F, Ret>(self, op: F) -> (Spec, Ret)
+    where
+        F: FnOnce() -> Ret,
+    {
+        let mut collector = new();
+        collector.spec = self.spec;
+
+        let cell = RefCell::new(collector);
+
+        let ret = COLLECTOR.set(&cell, || op());
+        let mut spec = cell.into_inner().spec;
+        spec.openapi = "3.0.1".into();
+        (spec, ret)
+    }
+}

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -10,14 +10,13 @@ use std::collections::BTreeMap;
 /// `#[schema(example = "path_to_function")]`
 pub trait Entity {
     fn describe() -> Schema;
-}
 
-pub trait ResponseEntity: Entity {
     fn describe_response() -> Response {
         let schema = Self::describe();
         let mut content = BTreeMap::new();
         content.insert(
-            "200".into(),
+            // TODO
+            "*/*".into(),
             MediaType {
                 schema: Some(ObjectOrReference::Object(schema)),
                 examples: None,
@@ -60,6 +59,8 @@ where
     fn describe() -> Schema {
         T::describe()
     }
+
+    // TODD: Json content type
 }
 
 impl<T> Entity for Query<T>
@@ -93,6 +94,7 @@ macro_rules! number {
                 }
             }
         }
+
     };
 
     (

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -10,6 +10,9 @@ use std::collections::BTreeMap;
 /// `#[schema(example = "path_to_function")]`
 pub trait Entity {
     fn describe() -> Schema;
+    fn describe_component() -> Option<Schema> {
+        None
+    }
 
     fn describe_response() -> Response {
         let schema = Self::describe();
@@ -38,6 +41,15 @@ impl<T: Entity> Entity for Vec<T> {
             ..Default::default()
         }
     }
+
+    fn describe_component() -> Option<Schema> {
+        let s = T::describe_component()?;
+        Some(Schema {
+            schema_type: Type::Array,
+            items: Some(Box::new(s)),
+            ..Default::default()
+        })
+    }
 }
 
 impl<T> Entity for Option<T>
@@ -49,6 +61,12 @@ where
         s.nullable = Some(true);
         s
     }
+
+    fn describe_component() -> Option<Schema> {
+        let mut s = T::describe_component()?;
+        s.nullable = Some(true);
+        Some(s)
+    }
 }
 
 impl<T> Entity for Json<T>
@@ -58,6 +76,10 @@ where
     #[inline]
     fn describe() -> Schema {
         T::describe()
+    }
+
+    fn describe_component() -> Option<Schema> {
+        T::describe_component()
     }
 
     fn describe_response() -> Response {
@@ -86,6 +108,10 @@ where
     fn describe() -> Schema {
         T::describe()
     }
+
+    fn describe_component() -> Option<Schema> {
+        T::describe_component()
+    }
 }
 
 impl<T> Entity for Form<T>
@@ -95,6 +121,10 @@ where
     #[inline]
     fn describe() -> Schema {
         T::describe()
+    }
+
+    fn describe_component() -> Option<Schema> {
+        T::describe_component()
     }
 }
 

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -73,6 +73,17 @@ where
     }
 }
 
+impl Entity for () {
+    /// Returns empty schema
+    #[inline(always)]
+    fn describe() -> Schema {
+        Schema {
+            schema_type: Type::Object,
+            ..Default::default()
+        }
+    }
+}
+
 impl<T> Entity for Json<T>
 where
     T: Entity,

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -1,7 +1,7 @@
 use crate::{Form, Json, Query};
 pub use rweb_openapi::v3_0::*;
 use std::{borrow::Cow, collections::BTreeMap, convert::Infallible};
-use warp::Rejection;
+use warp::{Rejection, Reply};
 
 pub type Components = Vec<(Cow<'static, str>, Schema)>;
 
@@ -50,6 +50,28 @@ impl<T: Entity> Entity for Vec<T> {
                 )
             })
             .collect()
+    }
+}
+
+impl<T> Entity for Box<T>
+where
+    T: Entity,
+{
+    fn describe() -> Schema {
+        T::describe()
+    }
+
+    fn describe_components() -> Components {
+        T::describe_components()
+    }
+}
+
+impl<T> ResponseEntity for Box<T>
+where
+    T: ResponseEntity,
+{
+    fn describe_responses() -> Responses {
+        T::describe_responses()
     }
 }
 
@@ -364,6 +386,22 @@ impl Entity for http::Error {
 }
 
 impl ResponseEntity for http::Error {
+    fn describe_responses() -> Responses {
+        Default::default()
+    }
+}
+
+impl Entity for dyn Reply {
+    fn describe() -> Schema {
+        <() as Entity>::describe()
+    }
+
+    fn describe_components() -> Vec<(Cow<'static, str>, Schema)> {
+        Default::default()
+    }
+}
+
+impl ResponseEntity for dyn Reply {
     fn describe_responses() -> Responses {
         Default::default()
     }

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -55,7 +55,7 @@ impl<T: Entity> Entity for Vec<T> {
 
 impl<T> Entity for Box<T>
 where
-    T: Entity,
+    T: ?Sized + Entity,
 {
     fn describe() -> Schema {
         T::describe()
@@ -68,7 +68,7 @@ where
 
 impl<T> ResponseEntity for Box<T>
 where
-    T: ResponseEntity,
+    T: ?Sized + ResponseEntity,
 {
     fn describe_responses() -> Responses {
         T::describe_responses()

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -186,6 +186,33 @@ integer!(u8, u16, u32, u64, u128, usize);
 integer!(i8, i16, i32, i64, i128, isize);
 // TODO: non-zero types
 
+macro_rules! number {
+    ($T:ty) => {
+        impl Entity for $T {
+            #[inline]
+            fn describe() -> Schema {
+                Schema {
+                    schema_type: Type::Number,
+                    ..Default::default()
+                }
+            }
+        }
+    };
+}
+
+number!(f32);
+number!(f64);
+
+impl Entity for bool {
+    #[inline]
+    fn describe() -> Schema {
+        Schema {
+            schema_type: Type::Boolean,
+            ..Default::default()
+        }
+    }
+}
+
 impl Entity for String {
     fn describe() -> Schema {
         Schema {

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -1,6 +1,7 @@
 use crate::{Form, Json, Query};
 pub use rweb_openapi::v3_0::*;
 use std::{borrow::Cow, collections::BTreeMap, convert::Infallible};
+use warp::Rejection;
 
 pub type Components = Vec<(Cow<'static, str>, Schema)>;
 
@@ -315,6 +316,22 @@ impl Entity for Infallible {
 
 impl ResponseEntity for Infallible {
     #[inline]
+    fn describe_responses() -> Responses {
+        Default::default()
+    }
+}
+
+impl Entity for Rejection {
+    fn describe() -> Schema {
+        <() as Entity>::describe()
+    }
+
+    fn describe_components() -> Vec<(Cow<'static, str>, Schema)> {
+        Default::default()
+    }
+}
+
+impl ResponseEntity for Rejection {
     fn describe_responses() -> Responses {
         Default::default()
     }

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -60,7 +60,22 @@ where
         T::describe()
     }
 
-    // TODD: Json content type
+    fn describe_response() -> Response {
+        let schema = Self::describe();
+        let mut content = BTreeMap::new();
+        content.insert(
+            "application/json".into(),
+            MediaType {
+                schema: Some(ObjectOrReference::Object(schema)),
+                examples: None,
+                encoding: Default::default(),
+            },
+        );
+        Response {
+            content,
+            ..Default::default()
+        }
+    }
 }
 
 impl<T> Entity for Query<T>

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -33,7 +33,7 @@ pub trait Entity {
 impl<T: Entity> Entity for Vec<T> {
     fn describe() -> Schema {
         Schema {
-            schema_type: "array".into(),
+            schema_type: Type::Array,
             items: Some(Box::new(T::describe())),
             ..Default::default()
         }
@@ -98,13 +98,13 @@ where
     }
 }
 
-macro_rules! number {
+macro_rules! integer {
     ($T:ty) => {
         impl Entity for $T {
             #[inline]
             fn describe() -> Schema {
                 Schema {
-                    schema_type: "number".to_string(),
+                    schema_type: Type::Integer,
                     ..Default::default()
                 }
             }
@@ -118,19 +118,19 @@ macro_rules! number {
         ),*
     ) => {
         $(
-            number!($T);
+            integer!($T);
         )*
     };
 }
 
-number!(u8, u16, u32, u64, u128, usize);
-number!(i8, i16, i32, i64, i128, isize);
+integer!(u8, u16, u32, u64, u128, usize);
+integer!(i8, i16, i32, i64, i128, isize);
 // TODO: non-zero types
 
 impl Entity for String {
     fn describe() -> Schema {
         Schema {
-            schema_type: "string".to_string(),
+            schema_type: Type::String,
             ..Default::default()
         }
     }

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -1,6 +1,6 @@
 use crate::{Form, Json, Query};
 pub use rweb_openapi::v3_0::*;
-use std::{borrow::Cow, collections::BTreeMap};
+use std::{borrow::Cow, collections::BTreeMap, convert::Infallible};
 
 pub type Components = Vec<(Cow<'static, str>, Schema)>;
 
@@ -96,7 +96,7 @@ where
 
 impl Entity for () {
     /// Returns empty schema
-    #[inline(always)]
+    #[inline]
     fn describe() -> Schema {
         Schema {
             schema_type: Type::Object,
@@ -233,6 +233,7 @@ impl Entity for bool {
 }
 
 impl Entity for String {
+    #[inline]
     fn describe() -> Schema {
         Schema {
             schema_type: Type::String,
@@ -297,5 +298,24 @@ where
         let mut map = T::describe_responses();
         map.extend(E::describe_responses());
         map
+    }
+}
+
+impl Entity for Infallible {
+    #[inline]
+    fn describe() -> Schema {
+        <() as Entity>::describe()
+    }
+
+    #[inline]
+    fn describe_components() -> Components {
+        vec![]
+    }
+}
+
+impl ResponseEntity for Infallible {
+    #[inline]
+    fn describe_responses() -> Responses {
+        Default::default()
     }
 }

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -1,0 +1,120 @@
+use crate::{Form, Json, Query};
+pub use rweb_openapi::v3_0::*;
+use std::collections::BTreeMap;
+
+/// This can be derived by `#[derive(Schema)]`.
+///
+///
+/// You may provide an example value of each field with
+///
+/// `#[schema(example = "path_to_function")]`
+pub trait Entity {
+    fn describe() -> Schema;
+}
+
+pub trait ResponseEntity: Entity {
+    fn describe_response() -> Response {
+        let schema = Self::describe();
+        let mut content = BTreeMap::new();
+        content.insert(
+            "200".into(),
+            MediaType {
+                schema: Some(ObjectOrReference::Object(schema)),
+                examples: None,
+                encoding: Default::default(),
+            },
+        );
+        Response {
+            content,
+            ..Default::default()
+        }
+    }
+}
+
+impl<T: Entity> Entity for Vec<T> {
+    fn describe() -> Schema {
+        Schema {
+            schema_type: "array".into(),
+            items: Some(Box::new(T::describe())),
+            ..Default::default()
+        }
+    }
+}
+
+impl<T> Entity for Option<T>
+where
+    T: Entity,
+{
+    fn describe() -> Schema {
+        let mut s = T::describe();
+        s.nullable = Some(true);
+        s
+    }
+}
+
+impl<T> Entity for Json<T>
+where
+    T: Entity,
+{
+    #[inline]
+    fn describe() -> Schema {
+        T::describe()
+    }
+}
+
+impl<T> Entity for Query<T>
+where
+    T: Entity,
+{
+    #[inline]
+    fn describe() -> Schema {
+        T::describe()
+    }
+}
+
+impl<T> Entity for Form<T>
+where
+    T: Entity,
+{
+    #[inline]
+    fn describe() -> Schema {
+        T::describe()
+    }
+}
+
+macro_rules! number {
+    ($T:ty) => {
+        impl Entity for $T {
+            #[inline]
+            fn describe() -> Schema {
+                Schema {
+                    schema_type: "number".to_string(),
+                    ..Default::default()
+                }
+            }
+        }
+    };
+
+    (
+        $(
+            $T:ty
+        ),*
+    ) => {
+        $(
+            number!($T);
+        )*
+    };
+}
+
+number!(u8, u16, u32, u64, u128, usize);
+number!(i8, i16, i32, i64, i128, isize);
+// TODO: non-zero types
+
+impl Entity for String {
+    fn describe() -> Schema {
+        Schema {
+            schema_type: "string".to_string(),
+            ..Default::default()
+        }
+    }
+}

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -352,3 +352,19 @@ impl ResponseEntity for Rejection {
         Default::default()
     }
 }
+
+impl Entity for http::Error {
+    fn describe() -> Schema {
+        <() as Entity>::describe()
+    }
+
+    fn describe_components() -> Vec<(Cow<'static, str>, Schema)> {
+        Default::default()
+    }
+}
+
+impl ResponseEntity for http::Error {
+    fn describe_responses() -> Responses {
+        Default::default()
+    }
+}

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -233,6 +233,22 @@ impl Entity for bool {
     }
 }
 
+impl<'a> Entity for &'a str {
+    #[inline]
+    fn describe() -> Schema {
+        Schema {
+            schema_type: Type::String,
+            ..Default::default()
+        }
+    }
+}
+
+impl<'a> ResponseEntity for &'a str {
+    fn describe_responses() -> Responses {
+        String::describe_responses()
+    }
+}
+
 impl Entity for String {
     #[inline]
     fn describe() -> Schema {

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -1,6 +1,6 @@
 //! Automatic openapi spec generator.
 
-pub use self::entity::{Entity, ResponseEntity};
+pub use self::entity::Entity;
 use crate::FromRequest;
 use http::Method;
 pub use rweb_openapi::v3_0::*;
@@ -93,7 +93,9 @@ impl Collector {
         op
     }
 
-    pub fn add_response_to<T: FromRequest + ResponseEntity>(mut op: Operation) -> Operation {
+    pub fn add_response_to<T: Entity>(mut op: Operation) -> Operation {
+        let resp = T::describe_response();
+        op.responses.insert("200".into(), resp);
         op
     }
 

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -51,6 +51,8 @@ impl Collector {
         if let Some((k, s)) = T::describe_component() {
             if self.spec.components.is_none() {
                 self.spec.components = Some(Default::default());
+                // TODO: Error reporting
+                // TODO: Remove duplicate work
                 self.spec
                     .components
                     .as_mut()

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -55,6 +55,74 @@
 //! rweb. If you use path filter from warp, generated document will point to
 //! different path.
 //!
+//! # Annotations
+//!
+//! This is applicable to `#[get]`, `#[post]`, ..etc
+//!
+//!
+//! ## `#[openapi(id = "foo")]`
+//!
+//! ```rust
+//! use rweb::*;
+//!
+//! #[get("/sum/{a}/{b}")]
+//! #[openapi(id = "math.sum")]
+//! fn sum(a: usize, b: usize) -> String {
+//!     (a + b).to_string()
+//! }
+//! ```
+//!
+//!
+//! ## `#[openapi(description = "foo")]`
+//!
+//! ```rust
+//! use rweb::*;
+//!
+//! /// By default, doc comments on the function will become description of the operation.
+//! #[get("/sum/{a}/{b}")]
+//! #[openapi(description = "But what if implementation details is written on it?")]
+//! fn sum(a: usize, b: usize) -> String {
+//!     (a + b).to_string()
+//! }
+//! ```
+//!
+//!
+//! ## `#[openapi(summary = "foo")]`
+//!
+//! ```rust
+//! use rweb::*;
+//!
+//! #[get("/sum/{a}/{b}")]
+//! #[openapi(summary = "summary of operation")]
+//! fn sum(a: usize, b: usize) -> String {
+//!     (a + b).to_string()
+//! }
+//! ```
+//!
+//! ## `#[openapi(tags("foo", "bar"))]`
+//!
+//! ```rust
+//! use rweb::*;
+//!
+//! #[get("/sum/{a}/{b}")]
+//! #[openapi(tags("sum"))]
+//! fn sum(a: usize, b: usize) -> String {
+//!     (a + b).to_string()
+//! }
+//!
+//! #[get("/mul/{a}/{b}")]
+//! #[openapi(tags("mul"))]
+//! fn mul(a: usize, b: usize) -> String {
+//!     (a * b).to_string()
+//! }
+//!
+//! // This is also applicable to #[router]
+//! #[router("/math", services(sum, mul))]
+//! #[openapi(tags("math"))]
+//! fn math() {}
+//! ```
+//!
+//!
 //! # Parameters
 //!
 //! ```rust

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -48,7 +48,9 @@ impl Collector {
     }
 
     pub fn add_request_type_to<T: FromRequest + Entity>(&mut self, op: &mut Operation) {
-        if let Some((k, s)) = T::describe_component() {
+        let comp = T::describe_component();
+
+        if let Some((k, s)) = comp.clone() {
             if self.spec.components.is_none() {
                 self.spec.components = Some(Default::default());
                 // TODO: Error reporting
@@ -66,6 +68,7 @@ impl Collector {
             if op.request_body.is_some() {
                 panic!("Multiple body detected");
             }
+
             let s = T::describe();
 
             let mut content = BTreeMap::new();
@@ -88,7 +91,7 @@ impl Collector {
         }
 
         if T::is_query() {
-            let s = T::describe();
+            let s = comp.map(|v| v.1).unwrap_or_else(T::describe);
 
             match s.schema_type {
                 Type::Object => {
@@ -105,7 +108,7 @@ impl Collector {
                         }))
                     }
                 }
-                _ => unimplemented!("other type than object"),
+                _ => {}
             }
         }
     }

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -1,12 +1,16 @@
 //! Automatic openapi spec generator.
 
-pub use self::entity::Entity;
+pub use self::{
+    builder::{spec, Builder},
+    entity::Entity,
+};
 use crate::FromRequest;
 use http::Method;
 pub use rweb_openapi::v3_0::*;
 use scoped_tls::scoped_thread_local;
 use std::{borrow::Cow, cell::RefCell, collections::BTreeMap, mem::replace};
 
+mod builder;
 mod entity;
 
 scoped_thread_local!(static COLLECTOR: RefCell<Collector>);
@@ -177,20 +181,6 @@ fn new() -> Collector {
         path_prefix: Default::default(),
         tags: vec![],
     }
-}
-
-pub fn spec<F, Ret>(op: F) -> (Spec, Ret)
-where
-    F: FnOnce() -> Ret,
-{
-    let collector = new();
-
-    let cell = RefCell::new(collector);
-
-    let ret = COLLECTOR.set(&cell, || op());
-    let mut spec = cell.into_inner().spec;
-    spec.openapi = "3.0.1".into();
-    (spec, ret)
 }
 
 #[doc(hidden)]

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -1,4 +1,45 @@
 //! Automatic openapi spec generator.
+//!
+//!
+//! # Basical usage
+//!
+//! Enable cargo feature by
+//!
+//!```toml
+//! [dependencies]
+//! rweb = { version = "0.3.0-alpha.1", features = ["openapi"] }
+//! ```
+//!
+//!and wrap your handlers like
+//!
+//! ```rust
+//! use rweb::*;
+//!
+//! #[get("/")]
+//! fn index() {
+//!
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let (spec, filter) = openapi::spec().build(||{
+//!            index()
+//!     });
+//!
+//!     serve(filter);
+//!     // Use the code below to run server.
+//!     //
+//!     // serve(filter).run(([127, 0, 0, 1], 3030)).await;
+//! }
+//! ```
+//!
+//!**Note**: Currently using path filter from warp is **not** supported by
+//! rweb. If you use path filter from warp, generated document will point to
+//! different path.
+//!
+//! # `#[derive(Schema)]`
+//!
+//! # Custom error
 
 pub use self::{
     builder::{spec, Builder},

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -4,7 +4,7 @@ pub use self::{
     builder::{spec, Builder},
     entity::Entity,
 };
-use crate::FromRequest;
+use crate::{openapi::entity::ResponseEntity, FromRequest};
 use http::Method;
 pub use rweb_openapi::v3_0::*;
 use scoped_tls::scoped_thread_local;
@@ -117,7 +117,7 @@ impl Collector {
         }
     }
 
-    pub fn add_response_to<T: Entity>(&mut self, op: &mut Operation) {
+    pub fn add_response_to<T: ResponseEntity>(&mut self, op: &mut Operation) {
         let resp = T::describe_response();
         op.responses.insert("200".into(), resp);
     }

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -48,7 +48,17 @@ impl Collector {
     }
 
     pub fn add_request_type_to<T: FromRequest + Entity>(&mut self, op: &mut Operation) {
-        if let Some(s) = T::describe_component() {}
+        if let Some((k, s)) = T::describe_component() {
+            if self.spec.components.is_none() {
+                self.spec.components = Some(Default::default());
+                self.spec
+                    .components
+                    .as_mut()
+                    .unwrap()
+                    .schemas
+                    .insert(k, ObjectOrReference::Object(s));
+            }
+        }
 
         if T::is_body() {
             if op.request_body.is_some() {

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -47,7 +47,9 @@ impl Collector {
         ret
     }
 
-    pub fn add_request_type_to<T: FromRequest + Entity>(mut op: Operation) -> Operation {
+    pub fn add_request_type_to<T: FromRequest + Entity>(&mut self, op: &mut Operation) {
+        if let Some(s) = T::describe_component() {}
+
         if T::is_body() {
             if op.request_body.is_some() {
                 panic!("Multiple body detected");
@@ -94,14 +96,11 @@ impl Collector {
                 _ => unimplemented!("other type than object"),
             }
         }
-
-        op
     }
 
-    pub fn add_response_to<T: Entity>(mut op: Operation) -> Operation {
+    pub fn add_response_to<T: Entity>(&mut self, op: &mut Operation) {
         let resp = T::describe_response();
         op.responses.insert("200".into(), resp);
-        op
     }
 
     #[doc(hidden)]

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -1,6 +1,6 @@
 pub use http::StatusCode;
 use std::convert::Infallible;
-pub use std::{borrow::Cow, clone::Clone};
+pub use std::{borrow::Cow, clone::Clone, collections::BTreeMap, default::Default};
 pub use tokio;
 use warp::{any, Filter};
 

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -1,6 +1,6 @@
 pub use http::StatusCode;
-pub use std::clone::Clone;
 use std::convert::Infallible;
+pub use std::{borrow::Cow, clone::Clone};
 pub use tokio;
 use warp::{any, Filter};
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "openapi"))]
+
 use rweb::{get, Filter, Rejection};
 
 async fn task() -> Result<String, Rejection> {

--- a/tests/body.rs
+++ b/tests/body.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "openapi"))]
+
 use bytes::Bytes;
 use http::Error;
 use rweb::{post, Filter};

--- a/tests/factory.rs
+++ b/tests/factory.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "openapi"))]
+
 use http::StatusCode;
 use rweb::{filters::BoxedFilter, *};
 use serde::Deserialize;

--- a/tests/mixed.rs
+++ b/tests/mixed.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "openapi"))]
+
 use http::Error;
 use rweb::*;
 use serde::{Deserialize, Serialize};

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -31,7 +31,7 @@ fn product(id: String) -> Product {
 }
 
 #[test]
-fn test1() {
+fn simple() {
     let (spec, _) = openapi::spec(|| {
         //
         product().or(products())
@@ -42,6 +42,38 @@ fn test1() {
 
     assert!(spec.paths.get("/product/{id}").is_some());
     assert!(spec.paths.get("/product/{id}").unwrap().get.is_some());
+
+    let yaml = serde_yaml::to_string(&spec).unwrap();
+    println!("{}", yaml);
+
+    panic!();
+}
+
+#[derive(Debug, Default, Serialize, Schema)]
+struct Resp<T> {
+    data: T,
+}
+
+#[derive(Debug, Default, Serialize, Schema)]
+struct Data {}
+
+#[get("/proxy")]
+fn proxy() -> Json<Resp<Data>> {
+    Resp {
+        data: Data::default(),
+    }
+    .into()
+}
+
+#[test]
+fn generic() {
+    let (spec, _) = openapi::spec(|| {
+        //
+        proxy()
+    });
+
+    assert!(spec.paths.get("/proxy").is_some());
+    assert!(spec.paths.get("/proxy").unwrap().get.is_some());
 
     let yaml = serde_yaml::to_string(&spec).unwrap();
     println!("{}", yaml);

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -33,7 +33,7 @@ fn product(id: String) -> Product {
 
 #[test]
 fn simple() {
-    let (spec, _) = openapi::spec(|| {
+    let (spec, _) = openapi::spec().build(|| {
         //
         product().or(products())
     });
@@ -73,7 +73,7 @@ fn proxy() -> Json<Resp<Data>> {
 
 #[test]
 fn generic() {
-    let (spec, _) = openapi::spec(|| {
+    let (spec, _) = openapi::spec().build(|| {
         //
         proxy()
     });
@@ -97,7 +97,7 @@ fn index() -> String {
 
 #[test]
 fn description() {
-    let (spec, _) = openapi::spec(|| {
+    let (spec, _) = openapi::spec().build(|| {
         //
         index()
     });

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -10,12 +10,11 @@ pub struct Product {
     pub title: String,
 }
 
-/// search-req=search-parameter
 #[derive(Debug, Default, Serialize, Deserialize, Schema)]
 pub struct SearchReq {
     pub query: String,
     pub limit: usize,
-    /// Token.
+    /// paging-token-example
     pub paging_token: String,
 }
 
@@ -48,7 +47,7 @@ fn simple() {
     let yaml = serde_yaml::to_string(&spec).unwrap();
     println!("{}", yaml);
 
-    assert!(yaml.contains("search-req=search-parameter"));
+    assert!(yaml.contains("paging-token-example"));
 }
 
 #[derive(Debug, Default, Serialize, Schema)]

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -10,6 +10,7 @@ pub struct Product {
     pub title: String,
 }
 
+/// search-req=search-parameter
 #[derive(Debug, Default, Serialize, Deserialize, Schema)]
 pub struct SearchReq {
     pub query: String,
@@ -46,6 +47,8 @@ fn simple() {
 
     let yaml = serde_yaml::to_string(&spec).unwrap();
     println!("{}", yaml);
+
+    assert!(yaml.contains("search-req=search-parameter"));
 }
 
 #[derive(Debug, Default, Serialize, Schema)]

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -1,0 +1,41 @@
+use rweb::*;
+use serde::{Deserialize, Serialize};
+use serde_yaml;
+
+#[derive(Debug, Default, Serialize, Deserialize, Schema)]
+pub struct Product {
+    pub id: String,
+    pub title: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Schema)]
+pub struct SearchReq {
+    pub query: String,
+    pub limit: usize,
+    pub paging_token: String,
+}
+
+#[get("/products")]
+fn products(_: Query<SearchReq>) -> Vec<Product> {
+    vec![]
+}
+
+#[get("/product/{id}")]
+fn product(id: String) -> Product {
+    Product {
+        id,
+        title: format!("Title of {}", id),
+    }
+}
+
+#[test]
+fn test1() {
+    let (spec, _) = openapi::spec(|| {
+        //
+        product().or(product())
+    });
+
+    println!("{}", serde_yaml::to_string(&spec).unwrap());
+
+    panic!();
+}

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -14,6 +14,7 @@ pub struct Product {
 pub struct SearchReq {
     pub query: String,
     pub limit: usize,
+    /// Token.
     pub paging_token: String,
 }
 
@@ -49,6 +50,7 @@ fn simple() {
 
 #[derive(Debug, Default, Serialize, Schema)]
 struct Resp<T> {
+    /// http-status-code
     status: usize,
     data: T,
 }
@@ -79,6 +81,8 @@ fn generic() {
 
     let yaml = serde_yaml::to_string(&spec).unwrap();
     println!("{}", yaml);
+
+    assert!(yaml.contains("http-status-code"));
 }
 
 /// Doc comment

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -19,16 +19,17 @@ pub struct SearchReq {
 }
 
 #[get("/products")]
-fn products(_: Query<SearchReq>) -> Vec<Product> {
-    vec![]
+fn products(_: Query<SearchReq>) -> Json<Vec<Product>> {
+    vec![].into()
 }
 
 #[get("/product/{id}")]
-fn product(id: String) -> Product {
+fn product(id: String) -> Json<Product> {
     Product {
         title: format!("Title of {}", id),
         id,
     }
+    .into()
 }
 
 #[test]

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -23,8 +23,8 @@ fn products(_: Query<SearchReq>) -> Vec<Product> {
 #[get("/product/{id}")]
 fn product(id: String) -> Product {
     Product {
-        id,
         title: format!("Title of {}", id),
+        id,
     }
 }
 
@@ -32,10 +32,17 @@ fn product(id: String) -> Product {
 fn test1() {
     let (spec, _) = openapi::spec(|| {
         //
-        product().or(product())
+        product().or(products())
     });
 
-    println!("{}", serde_yaml::to_string(&spec).unwrap());
+    assert!(spec.paths.get("/products").is_some());
+    assert!(spec.paths.get("/products").unwrap().get.is_some());
+
+    assert!(spec.paths.get("/product/{id}").is_some());
+    assert!(spec.paths.get("/product/{id}").unwrap().get.is_some());
+
+    let yaml = serde_yaml::to_string(&spec).unwrap();
+    println!("{}", yaml);
 
     panic!();
 }

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -65,6 +65,8 @@ fn proxy() -> Json<Resp<Data>> {
     .into()
 }
 
+// TODO: enum
+
 #[test]
 fn generic() {
     let (spec, _) = openapi::spec(|| {
@@ -77,6 +79,36 @@ fn generic() {
 
     let yaml = serde_yaml::to_string(&spec).unwrap();
     println!("{}", yaml);
+}
 
-    panic!();
+/// Doc comment
+#[get("/")]
+#[openapi(description = "foo-bar")]
+/// Doc comment
+fn index() -> String {
+    String::new()
+}
+
+#[test]
+fn description() {
+    let (spec, _) = openapi::spec(|| {
+        //
+        index()
+    });
+
+    assert!(spec.paths.get("/").is_some());
+    assert!(spec.paths.get("/").unwrap().get.is_some());
+    assert_eq!(
+        spec.paths
+            .get("/")
+            .unwrap()
+            .get
+            .as_ref()
+            .unwrap()
+            .description,
+        "foo-bar"
+    );
+
+    let yaml = serde_yaml::to_string(&spec).unwrap();
+    println!("{}", yaml);
 }

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "openapi")]
+
 use rweb::*;
 use serde::{Deserialize, Serialize};
 use serde_yaml;

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -45,12 +45,11 @@ fn simple() {
 
     let yaml = serde_yaml::to_string(&spec).unwrap();
     println!("{}", yaml);
-
-    panic!();
 }
 
 #[derive(Debug, Default, Serialize, Schema)]
 struct Resp<T> {
+    status: usize,
     data: T,
 }
 
@@ -60,6 +59,7 @@ struct Data {}
 #[get("/proxy")]
 fn proxy() -> Json<Resp<Data>> {
     Resp {
+        status: 200,
         data: Data::default(),
     }
     .into()

--- a/tests/openapi_enum.rs
+++ b/tests/openapi_enum.rs
@@ -13,6 +13,7 @@ fn index(_: Json<Enum>) -> String {
 enum Enum {
     A(String),
     B(usize),
+    Ref { ref_path: String },
 }
 
 #[test]

--- a/tests/openapi_enum.rs
+++ b/tests/openapi_enum.rs
@@ -13,7 +13,10 @@ fn index(_: Json<Enum>) -> String {
 enum Enum {
     A(String),
     B(usize),
-    Ref { ref_path: String },
+    Ref {
+        /// Reference-foo-bar-baz
+        ref_path: String,
+    },
 }
 
 #[test]
@@ -28,4 +31,6 @@ fn description() {
 
     let yaml = serde_yaml::to_string(&spec).unwrap();
     println!("{}", yaml);
+
+    assert!(yaml.contains("Reference-foo-bar-baz"));
 }

--- a/tests/openapi_enum.rs
+++ b/tests/openapi_enum.rs
@@ -21,7 +21,7 @@ enum Enum {
 
 #[test]
 fn description() {
-    let (spec, _) = openapi::spec(|| {
+    let (spec, _) = openapi::spec().build(|| {
         //
         index()
     });

--- a/tests/openapi_enum.rs
+++ b/tests/openapi_enum.rs
@@ -1,0 +1,30 @@
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::{Deserialize, Serialize};
+use serde_yaml;
+
+#[get("/")]
+fn index(_: Json<Enum>) -> String {
+    String::new()
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+enum Enum {
+    A(String),
+    B(usize),
+}
+
+#[test]
+fn description() {
+    let (spec, _) = openapi::spec(|| {
+        //
+        index()
+    });
+
+    assert!(spec.paths.get("/").is_some());
+    assert!(spec.paths.get("/").unwrap().get.is_some());
+
+    let yaml = serde_yaml::to_string(&spec).unwrap();
+    println!("{}", yaml);
+}

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -62,6 +62,4 @@ fn component_test() {
 
     let yaml = serde_yaml::to_string(&spec).unwrap();
     println!("{}", yaml);
-
-    panic!()
 }

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -1,8 +1,30 @@
 #![cfg(feature = "openapi")]
 
-use http::Error;
-use rweb::*;
+use rweb::{
+    rt::{BTreeMap, Cow},
+    *,
+};
+use rweb_openapi::v3_0::Response;
 use serde::Serialize;
+
+#[derive(Debug, Schema)]
+enum Error {}
+
+impl openapi::ResponseEntity for Error {
+    fn describe_responses() -> openapi::Responses {
+        let mut map = BTreeMap::new();
+
+        map.insert(
+            Cow::Borrowed("404"),
+            Response {
+                description: Cow::Borrowed("Product not found"),
+                ..Default::default()
+            },
+        );
+
+        map
+    }
+}
 
 #[derive(Debug, Serialize, Schema)]
 struct Resp<T> {
@@ -11,7 +33,7 @@ struct Resp<T> {
 }
 
 #[get("/")]
-fn index() -> Json<Resp<()>> {
+fn index() -> Result<Json<Resp<()>>, Error> {
     unimplemented!()
 }
 
@@ -29,7 +51,7 @@ fn product() -> Result<Json<Product>, Error> {
 #[response(400, description = "Invalid query")]
 #[response(400, description = "Invalid header")]
 #[response(404, description = "No product matches the query")]
-fn products() -> Json<Vec<Product>> {
+fn products() -> Result<Json<Vec<Product>>, Error> {
     unimplemented!()
 }
 

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -41,16 +41,11 @@ fn index() -> Result<Json<Resp<()>>, Error> {
 struct Product {}
 
 #[get("/product")]
-#[response(400)]
-#[response(404)]
 fn product() -> Result<Json<Product>, Error> {
     unimplemented!()
 }
 
 #[get("/product")]
-#[response(400, description = "Invalid query")]
-#[response(400, description = "Invalid header")]
-#[response(404, description = "No product matches the query")]
 fn products() -> Result<Json<Vec<Product>>, Error> {
     unimplemented!()
 }

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -4,6 +4,7 @@ use rweb::*;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Schema)]
+//#[schema(response)]
 struct Resp<T> {
     status: usize,
     data: T,

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "openapi")]
 
+use http::Error;
 use rweb::*;
 use serde::Serialize;
 
@@ -20,7 +21,7 @@ struct Product {}
 #[get("/product")]
 #[response(400)]
 #[response(404)]
-fn product() -> Json<Product> {
+fn product() -> Result<Json<Product>, Error> {
     unimplemented!()
 }
 

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -4,20 +4,31 @@ use rweb::*;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Schema)]
-//#[schema(response)]
 struct Resp<T> {
     status: usize,
     data: T,
 }
 
 #[get("/")]
-fn index() -> Resp<()> {
+fn index() -> Json<Resp<()>> {
     unimplemented!()
 }
 
-#[get("/example")]
-#[response()]
-fn example() -> Resp<()> {
+#[derive(Debug, Serialize, Schema)]
+struct Product {}
+
+#[get("/product")]
+#[response(400)]
+#[response(404)]
+fn product() -> Json<Product> {
+    unimplemented!()
+}
+
+#[get("/product")]
+#[response(400, description = "Invalid query")]
+#[response(400, description = "Invalid header")]
+#[response(404, description = "No product matches the query")]
+fn products() -> Json<Vec<Product>> {
     unimplemented!()
 }
 

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -1,0 +1,37 @@
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Schema)]
+struct Resp<T> {
+    status: usize,
+    data: T,
+}
+
+#[get("/")]
+fn index() -> Resp<()> {
+    unimplemented!()
+}
+
+#[get("/example")]
+#[response()]
+fn example() -> Resp<()> {
+    unimplemented!()
+}
+
+#[test]
+fn component_test() {
+    let (spec, _) = openapi::spec().build(|| {
+        //
+        index()
+    });
+
+    assert!(spec.paths.get("/").is_some());
+    assert!(spec.paths.get("/").unwrap().get.is_some());
+
+    let yaml = serde_yaml::to_string(&spec).unwrap();
+    println!("{}", yaml);
+
+    panic!()
+}

--- a/tests/openapi_schema.rs
+++ b/tests/openapi_schema.rs
@@ -1,0 +1,31 @@
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "Item")]
+struct ComponentTestReq {
+    data: String,
+}
+
+#[get("/")]
+fn component(_: Query<ComponentTestReq>) -> String {
+    String::new()
+}
+
+#[test]
+fn component_test() {
+    let (spec, _) = openapi::spec(|| {
+        //
+        component()
+    });
+
+    assert!(spec.paths.get("/").is_some());
+    assert!(spec.paths.get("/").unwrap().get.is_some());
+
+    let yaml = serde_yaml::to_string(&spec).unwrap();
+    println!("{}", yaml);
+
+    panic!()
+}

--- a/tests/openapi_schema.rs
+++ b/tests/openapi_schema.rs
@@ -27,6 +27,4 @@ fn component_test() {
 
     let yaml = serde_yaml::to_string(&spec).unwrap();
     println!("{}", yaml);
-
-    panic!()
 }

--- a/tests/openapi_schema.rs
+++ b/tests/openapi_schema.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Schema)]
 #[schema(component = "Item")]
+#[schema(description = "foo")]
 struct ComponentTestReq {
     data: String,
 }

--- a/tests/openapi_schema.rs
+++ b/tests/openapi_schema.rs
@@ -16,7 +16,7 @@ fn component(_: Query<ComponentTestReq>) -> String {
 
 #[test]
 fn component_test() {
-    let (spec, _) = openapi::spec(|| {
+    let (spec, _) = openapi::spec().build(|| {
         //
         component()
     });

--- a/tests/path_arg.rs
+++ b/tests/path_arg.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "openapi"))]
+
 use http::Error;
 use rweb::{get, Filter};
 

--- a/tests/state.rs
+++ b/tests/state.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "openapi"))]
+
 use futures::lock::Mutex;
 use rweb::*;
 use std::sync::Arc;


### PR DESCRIPTION
# Tasks
 - [x] Use doc comments as default description
 - [x] `#[openapi(description = "override")]`
 - [x] Reduce allocations. (Almost everything is static, but openapi crate does not accept &str at the moment)
 - [x] implement traits for `Option<T>`
 - [x] Builder to fill extra informations in spec. e.g.) title, version
 - [x] Implement `derive(Schema)`
   - [x] Basic impl
   - [x] Generics
   - [x] struct
   - [x] enum
   - [x] `#[schema(component = "Product")]` to store type under components and use `$ref`.
   - [x] Use doc comment as default description of field
   - [x] `#[schema(description = "")]` to override descrpition.
     - [x] struct
     - [x] enum
     - [x] enum variant
     - [x] field
 - [x] Reposne
    - [x] API design