### PR TITLE
[Merged by Bors] - Handle openapi request content-type

### DIFF
--- a/src/factory.rs
+++ b/src/factory.rs
@@ -31,6 +31,8 @@ pub trait FromRequest: Sized {
         false
     }
 
+    fn content_type() -> &'static str { "*/*" }
+
     fn new() -> Self::Filter;
 }
 
@@ -96,6 +98,8 @@ where
         true
     }
 
+    fn content_type() -> &'static str { "application/json" }
+
     fn new() -> Self::Filter {
         warp::body::json().boxed()
     }
@@ -130,6 +134,8 @@ where
     fn is_body() -> bool {
         true
     }
+
+    fn content_type() -> &'static str { "x-www-form-urlencoded" }
 
     fn new() -> Self::Filter {
         warp::body::form().boxed()

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -285,7 +285,7 @@ impl Collector {
 
             // TODO
             content.insert(
-                "*/*".into(),
+                Cow::Borrowed(T::content_type()),
                 MediaType {
                     schema: Some(ObjectOrReference::Object(s)),
                     examples: None,

--- a/tests/openapi_request.rs
+++ b/tests/openapi_request.rs
@@ -1,0 +1,59 @@
+#![feature(map_first_last)]
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::{Deserialize, Serialize};
+use serde_yaml;
+use rweb_openapi::v3_0::{ObjectOrReference};
+
+#[derive(Debug, Default, Serialize, Deserialize, Schema)]
+pub struct Product {
+    pub id: String,
+    pub title: String,
+}
+
+#[post("/json")]
+fn json(_: Json<Product>) -> String {
+    String::new()
+}
+
+#[post("/form")]
+fn form(_: Form<Product>) -> String { String::new() }
+
+#[test]
+fn description() {
+    let (spec, _) = openapi::spec().build(|| {
+        json().or(form())
+    });
+
+    assert!(spec.paths.get("/json").is_some());
+    assert!(spec.paths.get("/form").is_some());
+
+    assert!(spec.paths.get("/json").unwrap().post.is_some());
+    assert!(spec.paths.get("/form").unwrap().post.is_some());
+
+    assert!(spec.paths.get("/json").unwrap().post.as_ref().unwrap().request_body.is_some());
+    assert!(spec.paths.get("/form").unwrap().post.as_ref().unwrap().request_body.is_some());
+
+    match spec.paths.get("/json").unwrap().post.as_ref().unwrap().request_body.as_ref()
+        .unwrap() {
+        ObjectOrReference::Object(request_body) => {
+            assert!(request_body.content.contains_key("application/json"));
+        },
+        ObjectOrReference::Ref {  .. } =>
+            panic!("Struct Product dont have `#[schema(component = \"...\")]`"),
+    }
+
+    match spec.paths.get("/form").unwrap().post.as_ref().unwrap().request_body.as_ref()
+        .unwrap() {
+        ObjectOrReference::Object(request_body) => {
+            assert!(request_body.content.contains_key("x-www-form-urlencoded"));
+        },
+        ObjectOrReference::Ref {  .. } =>
+            panic!("Struct Product dont have `#[schema(component = \"...\")]`"),
+    }
+
+    let yaml = serde_yaml::to_string(&spec).unwrap();
+
+    println!("{}", yaml);
+}

--- a/tests/openapi_request.rs
+++ b/tests/openapi_request.rs
@@ -1,4 +1,3 @@
-#![feature(map_first_last)]
 #![cfg(feature = "openapi")]
 
 use rweb::*;


### PR DESCRIPTION
Hi,

`content-type` implementation  in openapi spec 

- application/json
- x-www-form-urlencoded

```bash
cargo test --test openapi_request  --all-features  -- --nocapture
running 1 test
---
openapi: 3.0.1
info:
  title: ""
  version: ""
paths:
  /form:
    post:
      requestBody:
        content:
          x-www-form-urlencoded: // <------
            schema:
              type: object
              properties:
                id:
                  type: string
                title:
                  type: string
        required: true
      responses:
        "200":
          description: ""
          content:
            text/plain:
              schema:
                type: string
  /json:
    post:
      requestBody:
        content:
          application/json: // <------
            schema:
              type: object
              properties:
                id:
                  type: string
                title:
                  type: string
        required: true
      responses:
        "200":
          description: ""
          content:
            text/plain:
              schema:
                type: string
test description ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```