### PR TITLE
update rweb version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installation (without automatic openapi generation):
 
 ```toml
 [dependencies]
-rweb = "0.4"
+rweb = "0.5"
 tokio = "0.2"
 ```
 


### PR DESCRIPTION
Otherwise it's a bit confusing, you paste the code to your project to try it out, and it doesn't work :thinking: 

But with the correct version, it gets better! :heart: 

Some long-term things that we can do to avoid such typo:
* somehow grep versions in Cargo.toml and README.md while doing tests in travis. Looks a bit dirty of an approach
* write a comment right here `# check latest version on https://crates.io/crates/rweb`

I'm a bit sleepy at the moment to make a choice on the last proposal. Thoughts?