### PR TITLE
Adding support for easy openapi UX interaction similar to FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,21 @@
 
 Yet another web server framework for rust.
 
-Installation (without automatic openapi generation):
+Installation:
 
 ```toml
 [dependencies]
-rweb = "0.5"
-tokio = "0.2"
+rweb = "0.6"
+tokio = "1"
+```
+
+Installation (with automatic openapi generation):
+
+```toml
+[dependencies]
+rweb = { version = "0.6", features = ["openapi"] }
+serde = "1"
+tokio = "1"
 ```
 
 # Features
@@ -91,6 +100,26 @@ fn example(ws: ws::Ws) -> String {
 rweb supports automatically generating openapi specification file based on your code.
 
 See: [documentation](https://docs.rs/rweb/latest/rweb/openapi/index.html) for usage.
+
+- API UX interaction for openapi
+
+```rust
+// Build openapi for your API
+let (spec, filter) = openapi::spec().build(move || {
+    // Your API's filters
+    math::math()
+        .or(products::products())
+        .or(generic::body())
+        .or(generic::optional())
+        .or(generic::search())
+        .or(response::response())
+});
+
+println!("go to http://localhost:3030/docs to interact with your openapi!");
+serve(filter.or(openapi_docs(spec)))
+    .run(([127, 0, 0, 1], 3030))
+    .await;
+```
 
 # Comparison
 

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 #[tokio::main]
 async fn main() {
-    let (spec, _filter) = openapi::spec().build(|| {
+    let (spec, filter) = openapi::spec().build(move || {
         // Build filters
 
         math::math()
@@ -14,7 +14,10 @@ async fn main() {
             .or(response::response())
     });
 
-    println!("{}", serde_yaml::to_string(&spec).unwrap());
+    println!("go to http://localhost:3030/docs to interact with your openapi!");
+    serve(filter.or(openapi_docs(spec)))
+        .run(([127, 0, 0, 1], 3030))
+        .await;
 }
 
 mod response {

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -1,0 +1,53 @@
+use crate::openapi::Spec;
+use warp::filters::BoxedFilter;
+use warp::Filter;
+use warp::Reply;
+
+/// Helper filter that exposes an openapi spec on the `/docs` endpoint.
+///
+/// # Example - single use with data injection
+///
+/// ```ignore
+/// let (spec, filter) = openapi::spec().build(|| index());
+/// serve(filter.or(openapi_docs(spec)))
+/// .run(([127, 0, 0, 1], 3030))
+/// .await;
+/// ```
+pub fn openapi_docs(spec: Spec) -> BoxedFilter<(impl Reply,)> {
+    let docs_openapi = warp::path("openapi.json").map(move || warp::reply::json(&spec.to_owned()));
+    let docs = warp::path("docs").map(|| {
+        return warp::reply::html(
+            r#"
+            <!doctype html>
+            <html lang="en">
+            <head>
+            <title>rweb</title>
+            <link href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css" rel="stylesheet">
+            </head>
+            <body>
+                <div id="swagger-ui"></div>
+                <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-bundle.js" charset="UTF-8"> </script>
+                <script>
+                    window.onload = function() {
+                    const ui = SwaggerUIBundle({
+                        "dom_id": "\#swagger-ui",
+                        presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIBundle.SwaggerUIStandalonePreset
+                        ],
+                        layout: "BaseLayout",
+                        deepLinking: true,
+                        showExtensions: true,
+                        showCommonExtensions: true,
+                        url: "/openapi.json",
+                    })
+                    window.ui = ui;
+                };
+            </script>
+            </body>
+            </html>
+        "#,
+        );
+    });
+    docs.or(docs_openapi).boxed()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,10 @@ pub use self::factory::{Form, FromRequest, Json, Query};
 pub use rweb_macros::{delete, get, head, options, patch, post, put, router, Schema};
 pub use warp::{self, *};
 
+#[cfg(feature = "openapi")]
+pub mod docs;
+#[cfg(feature = "openapi")]
+pub use self::docs::*;
 mod factory;
 #[cfg(feature = "openapi")]
 pub mod openapi;

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -5,10 +5,11 @@
 //!
 //! Enable cargo feature by
 //!
-//!```toml
+//! ```toml
 //! [dependencies]
-//! rweb = { version = "0.3.0-alpha.1", features = ["openapi"] }
-//! tokio = "0.2"
+//! rweb = { version = "0.6", features = ["openapi"] }
+//! serde = "1"
+//! tokio = "1"
 //! ```
 //!
 //! and wrap your handlers like


### PR DESCRIPTION
Hey there! I'm a huge fan of FastAPI and how easy it is to just get to interacting with their apis with an easy "localhost:8080/docs", I implemented a similar warp filter that can easily be used by people who use the openapi feature.  

Should just be able to:

```
cargo run --features="openapi"  --example openapi
```

To check it out.