### PR TITLE
openapi(response) to specify additional response codes

### DIFF
--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -82,6 +82,7 @@ mod products {
     #[get("/{id}")]
     #[openapi(id = "products.get")]
     #[openapi(summary = "Get a product")]
+    #[openapi(response(code = "404", description = "Product not found"))]
     fn product(id: String) -> Json<Product> {
         Product {
             id,

--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -324,6 +324,13 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
                                                 invalid_usage!()
                                             }
                                         }
+                                        Lit::Int(i) => {
+                                            if i.base10_parse::<u16>().is_ok() {
+                                                code = Some(i.to_string())
+                                            } else {
+                                                invalid_usage!()
+                                            }
+                                        }
                                         _ => invalid_usage!(),
                                     },
                                     _ => invalid_usage!(),

--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -289,7 +289,6 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
                                             );
                                         }
                                     };
-                                    println!("{:?}", op.responses);
                                 }
                                 _ => invalid_usage!(),
                             }

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -84,6 +84,7 @@ fn component_in_response() {
 #[get("/errable")]
 #[openapi(response(code = "417", description = "🍵"))]
 #[openapi(response(code = "5XX", description = "😵"))]
+#[openapi(response(code = "201", description = "✨", schema = "Json<Resp<String>>"))]
 fn errable() -> Json<()> {
     unimplemented!()
 }
@@ -96,4 +97,11 @@ fn response_code_in_response() {
     assert!(op.responses.get("417").unwrap().description == "🍵");
     assert!(op.responses.get("5XX").is_some());
     assert!(op.responses.get("5XX").unwrap().description == "😵");
+    assert!(op
+        .responses
+        .get("201")
+        .unwrap()
+        .content
+        .get("application/json")
+        .is_some())
 }

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -92,7 +92,6 @@ fn errable() -> Json<()> {
 fn response_code_in_response() {
     let (spec, _) = openapi::spec().build(|| errable());
     let op = spec.paths.get("/errable").unwrap().get.as_ref().unwrap();
-    println!("{:?}", op.responses);
     assert!(op.responses.get("417").is_some());
     assert!(op.responses.get("417").unwrap().description == "🍵");
     assert!(op.responses.get("5XX").is_some());

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -84,7 +84,7 @@ fn component_in_response() {
 #[get("/errable")]
 #[openapi(response(code = "417", description = "🍵"))]
 #[openapi(response(code = "5XX", description = "😵"))]
-#[openapi(response(code = "201", description = "✨", schema = "Json<Resp<String>>"))]
+#[openapi(response(code = 201, description = "✨", schema = "Json<Resp<String>>"))]
 fn errable() -> Json<()> {
     unimplemented!()
 }

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -80,3 +80,21 @@ fn component_in_response() {
     assert!(spec.paths.get("/item").unwrap().get.is_some());
     assert!(spec.components.unwrap().schemas.get("Item").is_some());
 }
+
+#[get("/errable")]
+#[openapi(response(code = "417", description = "🍵"))]
+#[openapi(response(code = "5XX", description = "😵"))]
+fn errable() -> Json<()> {
+    unimplemented!()
+}
+
+#[test]
+fn response_code_in_response() {
+    let (spec, _) = openapi::spec().build(|| errable());
+    let op = spec.paths.get("/errable").unwrap().get.as_ref().unwrap();
+    println!("{:?}", op.responses);
+    assert!(op.responses.get("417").is_some());
+    assert!(op.responses.get("417").unwrap().description == "🍵");
+    assert!(op.responses.get("5XX").is_some());
+    assert!(op.responses.get("5XX").unwrap().description == "😵");
+}


### PR DESCRIPTION
TLDR:
```rust
#[get("/{id}")]
#[openapi(response(code = "404", description = "Product not found"))]
fn product(id: String) -> Json<Product> { ... }
```

# `openapi(response)`
Allows defining additional response codes (and descriptions) for routes.

Currently the only way to do that is by implementing `openapi::ResponseEntity` yourself, with one impl for each combination of responses, and further complications if one trivially tries to return a `Result` (more on that in first comment). There's no way to do so for `dyn` responses.

Now, this is done with `response` openapi config on the route, by specifying 2 mandatory named parameters - `code` and `description` (resp "HTTP Status Code" and "description" in OpenAPI). The latter is a string, and code is either number or string [(OpenAPI allows range definitions ala `4XX` for status codes)](https://swagger.io/docs/specification/describing-responses).

Optional `schema` parameter allows to specify the type to use schema from for the response.
```rs
#[openapi(response(code = 201, description = "✨", schema = "Json<Resp<String>>"))]
```
This is _particularly_ useful for routes with `dyn` responses. Also works as a workaround for documenting errors sent via warp's reject&recover.