### PR TITLE
openapi Schema derive required

### DIFF
--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -368,12 +368,18 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
                             Fields::Named(..) => Some(Pair::Punctuated(
                                 {
                                     let fields = handle_fields(&attrs, &mut v.fields);
+                                    let fields_required = handle_fields_required(&attrs, &v.fields);
                                     q!(
-                                        Vars { fields, desc },
+                                        Vars {
+                                            fields,
+                                            fields_required,
+                                            desc
+                                        },
                                         ({
                                             #[allow(unused_mut)]
                                             let mut s = rweb::openapi::Schema {
                                                 properties: fields,
+                                                required: fields_required,
                                                 ..rweb::rt::Default::default()
                                             };
                                             let description = desc;

--- a/tests/openapi_required.rs
+++ b/tests/openapi_required.rs
@@ -1,0 +1,86 @@
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "TestStruct")]
+struct TestStruct {
+    afield: String,
+    optfield: Option<String>,
+}
+
+#[get("/")]
+fn test_struct_r(_: Query<TestStruct>) -> String {
+    String::new()
+}
+
+#[test]
+fn test_struct() {
+    let (spec, _) = openapi::spec().build(|| test_struct_r());
+    let schema = match spec
+        .components
+        .as_ref()
+        .unwrap()
+        .schemas
+        .get("TestStruct")
+        .unwrap()
+    {
+        openapi::ObjectOrReference::Object(s) => s,
+        _ => panic!(),
+    };
+    println!("{}", serde_yaml::to_string(&schema).unwrap());
+    assert!(schema.required.contains(&Cow::Borrowed("afield")));
+    assert!(!schema.required.contains(&Cow::Borrowed("optfield")));
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "TestEnum")]
+enum TestEnum {
+    AThing {
+        afield: String,
+    },
+    MaybeThing {
+        optfield: Option<String>,
+    },
+    TwoThings {
+        afield: String,
+        optfield: Option<String>,
+    },
+}
+
+#[get("/")]
+fn test_enum_r(_: Query<TestEnum>) -> String {
+    String::new()
+}
+
+#[test]
+fn test_enum() {
+    let (spec, _) = openapi::spec().build(|| test_enum_r());
+    let schema = match spec
+        .components
+        .as_ref()
+        .unwrap()
+        .schemas
+        .get("TestEnum")
+        .unwrap()
+    {
+        openapi::ObjectOrReference::Object(s) => s,
+        _ => panic!(),
+    };
+    println!("{}", serde_yaml::to_string(&schema).unwrap());
+    for variant in &schema.one_of {
+        match variant {
+            openapi::ObjectOrReference::Object(vs) => {
+                if vs.properties.contains_key(&Cow::Borrowed("afield")) {
+                    assert!(vs.required.contains(&Cow::Borrowed("afield")));
+                }
+                if vs.properties.contains_key(&Cow::Borrowed("optfield")) {
+                    assert!(!vs.required.contains(&Cow::Borrowed("optfield")));
+                }
+            }
+            _ => panic!(),
+        }
+    }
+}


### PR DESCRIPTION
TLDR: Fixes #50 

For both enums and structs, populates derived schema's `required` property with all non-nullable fields.
in other words, all fields except those that are nullable.

The behaviour can be further improved by also ignoring fields that have serde `skip_serializing_if` attribute.
Though technically speaking it would be correct to _only_ exclude fields that have `skip_serializing_if` attribute (which will allow the spec to contain nullable required fields).