### PR TITLE
openapi schema subcomponents, components with generics, generic subcomponents...

### DIFF
--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -451,7 +451,7 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
                                 rweb::openapi::schema_consistent_component_name(
                                     &<tpn as rweb::openapi::Entity>::describe(),
                                 )
-                                .unwrap()
+                                .expect("To use generic components, all type parameters must themselves be components (or lists of)")
                             }
                         })
                     }),

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -448,25 +448,10 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
                         let tpn = &t.ident;
                         q!(Vars { tpn }, {
                             {
-                                let ts = <tpn as rweb::openapi::Entity>::describe();
-                                if ts.ref_path.is_empty() {
-                                    match ts.schema_type {
-                                        Some(rweb::openapi::Type::String) => "string".to_string(),
-                                        Some(rweb::openapi::Type::Number) => "number".to_string(),
-                                        Some(rweb::openapi::Type::Integer) => "integer".to_string(),
-                                        Some(rweb::openapi::Type::Boolean) => "boolean".to_string(),
-                                        //TODO Array..?
-                                        _ => std::any::type_name::<tpn>()
-                                            .replace("::", ".")
-                                            .replace(":", ".")
-                                            .replace("<", "-_")
-                                            .replace(">", "_-")
-                                            .replace(", ", "_")
-                                            .replace(",", "_"),
-                                    }
-                                } else {
-                                    ts.ref_path[("#/components/schemas/".len())..].to_string()
-                                }
+                                rweb::openapi::schema_consistent_component_name(
+                                    &<tpn as rweb::openapi::Entity>::describe(),
+                                )
+                                .unwrap()
                             }
                         })
                     }),

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -439,7 +439,12 @@ pub fn schema_consistent_component_name(s: &Schema) -> Result<String, &'static s
             Some(Type::Number) => Ok("number".to_string()),
             Some(Type::Integer) => Ok("integer".to_string()),
             Some(Type::Boolean) => Ok("boolean".to_string()),
-            //TODO Array..?
+            Some(Type::Array) => Ok("-".to_string()
+                + schema_consistent_component_name(
+                    s.items.as_ref().ok_or("array types must declare `items`")?,
+                )?
+                .as_str()
+                + "-"),
             _ => Err("anonymous types don't have component names"),
         }
     } else {

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -439,12 +439,9 @@ pub fn schema_consistent_component_name(s: &Schema) -> Result<String, &'static s
             Some(Type::Number) => Ok("number".to_string()),
             Some(Type::Integer) => Ok("integer".to_string()),
             Some(Type::Boolean) => Ok("boolean".to_string()),
-            Some(Type::Array) => Ok("-".to_string()
-                + schema_consistent_component_name(
-                    s.items.as_ref().ok_or("array types must declare `items`")?,
-                )?
-                .as_str()
-                + "-"),
+            Some(Type::Array) => Ok(schema_consistent_component_name(
+                s.items.as_ref().ok_or("array types must declare `items`")?,
+            )? + "_List"),
             _ => Err("anonymous types don't have component names"),
         }
     } else {

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -432,6 +432,21 @@ where
     }
 }
 
+pub fn schema_consistent_component_name(s: &Schema) -> Result<String, &'static str> {
+    if s.ref_path.is_empty() {
+        match s.schema_type {
+            Some(Type::String) => Ok("string".to_string()),
+            Some(Type::Number) => Ok("number".to_string()),
+            Some(Type::Integer) => Ok("integer".to_string()),
+            Some(Type::Boolean) => Ok("boolean".to_string()),
+            //TODO Array..?
+            _ => Err("anonymous types don't have component names"),
+        }
+    } else {
+        Ok(s.ref_path[("#/components/schemas/".len())..].to_string())
+    }
+}
+
 /// I'm too lazy to use inflector.
 #[doc(hidden)]
 pub mod http_methods {

--- a/tests/openapi_generic_multi_struct.rs
+++ b/tests/openapi_generic_multi_struct.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "One")]
+pub struct One {}
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "Two")]
+pub struct Two {}
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "GenericStruct")]
+struct GenericStruct<A, B> {
+    a: A,
+    b: B,
+}
+
+#[get("/")]
+fn test_r(
+    _: Query<GenericStruct<Option<One>, u64>>,
+    _: Json<Vec<GenericStruct<Vec<Two>, Option<GenericStruct<One, One>>>>>,
+) -> String {
+    String::new()
+}
+
+#[test]
+fn test_multi_generics_compile() {
+    let (spec, _) = openapi::spec().build(|| test_r());
+    let schemas = &spec.components.as_ref().unwrap().schemas;
+    println!("{}", serde_yaml::to_string(&schemas).unwrap());
+    for (name, _) in schemas {
+        assert!(name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '-'))
+    }
+    assert!(schemas.contains_key("One"));
+    assert!(schemas.contains_key("Two"));
+    assert!(schemas.contains_key("One_Opt"));
+    assert!(schemas.contains_key("Two_List"));
+    assert!(schemas.contains_key("GenericStruct-_One_One_-_Opt"));
+}

--- a/tests/openapi_generic_struct.rs
+++ b/tests/openapi_generic_struct.rs
@@ -23,8 +23,8 @@ fn test_r(
     _: Query<GenericStruct<String, u64>>,
     _: Json<
         GenericStruct<
-            GenericStruct<String, u64>,
-            GenericStruct<String, GenericStructWithConst<i32, 16>>,
+            GenericStruct<String, Vec<u64>>,
+            GenericStruct<String, GenericStructWithConst<Vec<Vec<i32>>, 16>>,
         >,
     >,
 ) -> String {

--- a/tests/openapi_generic_struct.rs
+++ b/tests/openapi_generic_struct.rs
@@ -1,5 +1,3 @@
-//! https://github.com/kdy1/rweb/issues/38
-
 #![cfg(feature = "openapi")]
 
 use rweb::*;

--- a/tests/openapi_generic_struct.rs
+++ b/tests/openapi_generic_struct.rs
@@ -1,0 +1,44 @@
+//! https://github.com/kdy1/rweb/issues/38
+
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "GenericStruct")]
+struct GenericStruct<A, B> {
+    a: A,
+    b: B,
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "GenericStructWithConst")]
+struct GenericStructWithConst<A, const D: usize> {
+    a: A,
+}
+
+#[get("/")]
+fn test_r(
+    _: Query<GenericStruct<String, u64>>,
+    _: Json<
+        GenericStruct<
+            GenericStruct<String, u64>,
+            GenericStruct<String, GenericStructWithConst<i32, 16>>,
+        >,
+    >,
+) -> String {
+    String::new()
+}
+
+#[test]
+fn test_generics_compile() {
+    let (spec, _) = openapi::spec().build(|| test_r());
+    let schemas = &spec.components.as_ref().unwrap().schemas;
+    println!("{}", serde_yaml::to_string(&schemas).unwrap());
+    for (name, _) in schemas {
+        assert!(name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '-'))
+    }
+}

--- a/tests/openapi_multi_struct.rs
+++ b/tests/openapi_multi_struct.rs
@@ -13,8 +13,14 @@ pub struct One {}
 #[schema(component = "Two")]
 pub struct Two {}
 
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "Three")]
+pub struct Three {
+    two: Two,
+}
+
 #[get("/")]
-fn index(_: Query<One>, _: Json<Two>) -> String {
+fn index(_: Query<One>, _: Json<Three>) -> String {
     String::new()
 }
 
@@ -24,7 +30,9 @@ fn description() {
         //
         index()
     });
-
-    let yaml = serde_yaml::to_string(&spec).unwrap();
-    println!("{}", yaml);
+    let schemas = &spec.components.as_ref().unwrap().schemas;
+    println!("{}", serde_yaml::to_string(&schemas).unwrap());
+    assert!(schemas.contains_key("One"));
+    assert!(schemas.contains_key("Two"));
+    assert!(schemas.contains_key("Three"));
 }

--- a/tests/openapi_multi_struct.rs
+++ b/tests/openapi_multi_struct.rs
@@ -17,6 +17,7 @@ pub struct Two {}
 #[schema(component = "Three")]
 pub struct Three {
     two: Two,
+    list_of_opt_of_one: Vec<Option<One>>,
 }
 
 #[get("/")]
@@ -35,4 +36,11 @@ fn description() {
     assert!(schemas.contains_key("One"));
     assert!(schemas.contains_key("Two"));
     assert!(schemas.contains_key("Three"));
+    assert!(schemas.contains_key("One_Opt"));
+    assert!(schemas.contains_key("One_Opt_List"));
+    assert!(!schemas.contains_key("One_List"));
+    assert!(!schemas.contains_key("Two_List"));
+    assert!(!schemas.contains_key("Three_List"));
+    assert!(!schemas.contains_key("Two_Opt"));
+    assert!(!schemas.contains_key("Three_Opt"));
 }


### PR DESCRIPTION
TLDR: This allows usage of `schema(component)` on parametrized types.
```rust
#[schema(component = "GenericStruct")]
struct GenericStruct<A, B> {
    a: A,
    b: B,
}
```
Additionally: This fixes subcomponents-appearing-only-in-other-components not appearing in the final spec 🐛.

Currently it's simply impossible due to name conflict.

Usage of generic components requires that all types be themselves components or primitives (or arrays of).

It works by appending parametrization suffix to component's name. The suffix is assembled from component names of the generic parameters (and values for generic constants). For OpenAPI primitives, it's their shorthand names. Arrays get a special pre/suffix around inner type.
~~All of this means that as long as all types used in generic params are themselves components (or primitives), the generated suffix is consistent.~~ Basically this suffix is consistent, since anonymous/inline parameters fail to generate components (and every component's name is consistently defined, recursively now).