### PR TITLE
openapi(response) typo / 🐛 fix

### DIFF
--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -340,7 +340,7 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
                                 (Some(c), Some(d)) => {
                                     match op.responses.get_mut(&Cow::Owned(c.clone())) {
                                         Some(resp) => {
-                                            resp.description = Cow::Owned(c.clone());
+                                            resp.description = Cow::Owned(d);
                                         }
                                         None => {
                                             op.responses.insert(

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -338,8 +338,15 @@ impl Collector {
 
     pub fn add_response_to<T: ResponseEntity>(&mut self, op: &mut Operation) {
         self.add_components(T::describe_components());
-        let responces = T::describe_responses();
-        op.responses.extend(responces);
+        let mut responses = T::describe_responses();
+        for (code, mut resp) in &mut responses {
+            if let Some(ex_resp) = op.responses.remove(code) {
+                if !ex_resp.description.is_empty() {
+                    resp.description = ex_resp.description
+                }
+            }
+        }
+        op.responses.extend(responses);
     }
 
     fn add_components(&mut self, components: Components) {

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -84,6 +84,7 @@ fn component_in_response() {
 #[get("/errable")]
 #[openapi(response(code = "417", description = "🍵"))]
 #[openapi(response(code = "5XX", description = "😵"))]
+#[openapi(response(code = 200, description = "🐛"))]
 #[openapi(response(code = 201, description = "✨", schema = "Json<Resp<String>>"))]
 fn errable() -> Json<()> {
     unimplemented!()
@@ -97,6 +98,7 @@ fn response_code_in_response() {
     assert!(op.responses.get("417").unwrap().description == "🍵");
     assert!(op.responses.get("5XX").is_some());
     assert!(op.responses.get("5XX").unwrap().description == "😵");
+    assert_eq!(op.responses.get("200").unwrap().description, "🐛");
     assert!(op
         .responses
         .get("201")

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -95,9 +95,9 @@ fn response_code_in_response() {
     let (spec, _) = openapi::spec().build(|| errable());
     let op = spec.paths.get("/errable").unwrap().get.as_ref().unwrap();
     assert!(op.responses.get("417").is_some());
-    assert!(op.responses.get("417").unwrap().description == "🍵");
+    assert_eq!(op.responses.get("417").unwrap().description, "🍵");
     assert!(op.responses.get("5XX").is_some());
-    assert!(op.responses.get("5XX").unwrap().description == "😵");
+    assert_eq!(op.responses.get("5XX").unwrap().description, "😵");
     assert_eq!(op.responses.get("200").unwrap().description, "🐛");
     assert!(op
         .responses


### PR DESCRIPTION
~~Fixes a minor typo in #58 that lead to existing response's description being override with code string instead of new description.~~
Turns out it was more than just a typo. Addition of description migration had to be added to `Collector.add_response_to` as well.

The intended behaviour is to override with specified description.

The bug is minor as-in it doesn't affect all of primary use cases of `openapi(response)` and only concerns behaviour when overriding description of "existing" response (it's so minor i forgot to both mention this behaviour in original PR, and test it :D).