### PR TITLE
openapi derive schema acknowledge serde skip

### DIFF
--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -61,6 +61,31 @@ fn get_rename(attrs: &[Attribute]) -> Option<String> {
     })
 }
 
+fn get_skip_mode(attrs: &[Attribute]) -> (bool, bool) {
+    let mut ser = false;
+    let mut de = false;
+    for attr in attrs {
+        if attr.path.is_ident("serde") {
+            match parse2::<Paren<Meta>>(attr.tokens.clone()) {
+                Ok(Paren {
+                    inner: Meta::Path(pa),
+                }) => {
+                    if pa.is_ident("skip") {
+                        ser = true;
+                        de = true;
+                    } else if pa.is_ident("skip_serializing") {
+                        ser = true
+                    } else if pa.is_ident("skip_deserializing") {
+                        de = true
+                    }
+                }
+                Ok(..) | Err(..) => {}
+            };
+        }
+    }
+    (ser, de)
+}
+
 fn field_name(type_attrs: &[Attribute], field: &Field) -> String {
     if let Some(s) = get_rename(&field.attrs) {
         return s;
@@ -208,13 +233,19 @@ fn handle_field(type_attrs: &[Attribute], f: &mut Field) -> Stmt {
 
     let desc = extract_doc(&mut f.attrs);
     let example_v = extract_example(&mut f.attrs);
+    let (skip_ser, skip_de) = get_skip_mode(&f.attrs);
 
+    if skip_ser && skip_de {
+        return q!({ {} }).parse();
+    }
     q!(
         Vars {
             name_str,
             desc,
             Type: &f.ty,
             example_v: super::quote_option(example_v),
+            skip_ser,
+            skip_de,
         },
         {
             map.insert(rweb::rt::Cow::Borrowed(name_str), {
@@ -228,6 +259,9 @@ fn handle_field(type_attrs: &[Attribute], f: &mut Field) -> Stmt {
                     let example = example_v;
                     if let Some(example) = example {
                         s.example = Some(example);
+                    }
+                    if skip_de {
+                        s.read_only = Some(true);
                     }
                     s
                 }

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -260,6 +260,9 @@ fn handle_field(type_attrs: &[Attribute], f: &mut Field) -> Stmt {
                     if let Some(example) = example {
                         s.example = Some(example);
                     }
+                    if skip_ser {
+                        s.write_only = Some(true);
+                    }
                     if skip_de {
                         s.read_only = Some(true);
                     }

--- a/tests/openapi_skip.rs
+++ b/tests/openapi_skip.rs
@@ -1,0 +1,45 @@
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, rweb::Schema)]
+#[schema(component = "Whence")]
+struct Whence {
+    always: u64,
+    #[serde(skip_deserializing)]
+    only_yeet: u64,
+    #[serde(skip_serializing)]
+    only_take: u64,
+    #[serde(skip)]
+    nevah: u64,
+}
+
+#[get("/")]
+fn index(_: Query<Whence>) -> String {
+    String::new()
+}
+
+#[test]
+fn test_skip() {
+    let (spec, _) = openapi::spec().build(|| index());
+    let schemas = &spec.components.as_ref().unwrap().schemas;
+    println!("{}", serde_yaml::to_string(&schemas).unwrap());
+    let whence = match schemas.get("Whence").unwrap() {
+        rweb::openapi::ObjectOrReference::Object(s) => s,
+        _ => panic!(),
+    };
+    assert!(whence.properties.contains_key("always"));
+    assert!(whence.properties.contains_key("only_yeet"));
+    assert!(whence.properties.contains_key("only_take"));
+    assert!(!whence.properties.contains_key("nevah"));
+    assert_eq!(whence.properties.get("always").unwrap().read_only, None);
+    // assert_eq!(whence.properties.get("always").unwrap().write_only, None);
+    assert_eq!(
+        whence.properties.get("only_yeet").unwrap().read_only,
+        Some(true)
+    );
+    // assert_eq!(whence.properties.get("only_yeet").unwrap().write_only, None);
+    assert_eq!(whence.properties.get("only_take").unwrap().read_only, None);
+    // assert_eq!(whence.properties.get("only_take").unwrap().write_only, Some(true));
+}

--- a/tests/openapi_skip.rs
+++ b/tests/openapi_skip.rs
@@ -34,12 +34,15 @@ fn test_skip() {
     assert!(whence.properties.contains_key("only_take"));
     assert!(!whence.properties.contains_key("nevah"));
     assert_eq!(whence.properties.get("always").unwrap().read_only, None);
-    // assert_eq!(whence.properties.get("always").unwrap().write_only, None);
+    assert_eq!(whence.properties.get("always").unwrap().write_only, None);
     assert_eq!(
         whence.properties.get("only_yeet").unwrap().read_only,
         Some(true)
     );
-    // assert_eq!(whence.properties.get("only_yeet").unwrap().write_only, None);
+    assert_eq!(whence.properties.get("only_yeet").unwrap().write_only, None);
     assert_eq!(whence.properties.get("only_take").unwrap().read_only, None);
-    // assert_eq!(whence.properties.get("only_take").unwrap().write_only, Some(true));
+    assert_eq!(
+        whence.properties.get("only_take").unwrap().write_only,
+        Some(true)
+    );
 }


### PR DESCRIPTION
TLDR: Closes #54 

Detects `serde(skip)` family of attributes, and removes always skipped properties. Marks de skipped properties as read-only.
Should mark ser skipped as write-only, but required fields is missing in schema.