### PR TITLE
openapi impl entity for fixed size arrays

### DIFF
--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -569,6 +569,43 @@ where
     }
 }
 
+impl<T: Entity> Entity for (T, T) {
+    fn describe() -> Schema {
+        <[T; 2] as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <[T; 2] as Entity>::describe_components()
+    }
+}
+impl<T: Entity> Entity for (T, T, T) {
+    fn describe() -> Schema {
+        <[T; 3] as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <[T; 3] as Entity>::describe_components()
+    }
+}
+impl<T: Entity> Entity for (T, T, T, T) {
+    fn describe() -> Schema {
+        <[T; 4] as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <[T; 4] as Entity>::describe_components()
+    }
+}
+impl<T: Entity> Entity for (T, T, T, T, T) {
+    fn describe() -> Schema {
+        <[T; 5] as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <[T; 5] as Entity>::describe_components()
+    }
+}
+
 impl<T: Entity> Entity for HashMap<Arc<String>, T> {
     fn describe() -> Schema {
         <HashMap<String, T> as Entity>::describe()

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -343,6 +343,16 @@ impl<T: Entity> Entity for [T] {
     }
 }
 
+impl<T: Entity, const N: usize> Entity for [T; N] {
+    fn describe() -> Schema {
+        <[T] as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <[T] as Entity>::describe_components()
+    }
+}
+
 impl<T> Entity for Option<T>
 where
     T: Entity,

--- a/tests/openapi_arr_length.rs
+++ b/tests/openapi_arr_length.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "openapi")]
 
+use std::collections::HashSet;
+
 use rweb::*;
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +11,7 @@ struct Things {
     yarr: [u64; 24],
     yarr0: [u64; 0],
     tuple: (String, String, String),
+    set: HashSet<String>,
 }
 
 #[get("/")]
@@ -59,6 +62,21 @@ fn test_skip() {
         things
             .properties
             .get("tuple")
+            .unwrap()
+            .items
+            .as_ref()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::String)
+    );
+    assert_eq!(
+        things.properties.get("set").unwrap().unique_items,
+        Some(true)
+    );
+    assert_eq!(
+        things
+            .properties
+            .get("set")
             .unwrap()
             .items
             .as_ref()

--- a/tests/openapi_arr_length.rs
+++ b/tests/openapi_arr_length.rs
@@ -1,0 +1,69 @@
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, rweb::Schema)]
+#[schema(component = "Things")]
+struct Things {
+    yarr: [u64; 24],
+    yarr0: [u64; 0],
+    tuple: (String, String, String),
+}
+
+#[get("/")]
+fn index(_: Query<Things>) -> String {
+    String::new()
+}
+
+#[test]
+fn test_skip() {
+    let (spec, _) = openapi::spec().build(|| index());
+    let schemas = &spec.components.as_ref().unwrap().schemas;
+    let things = match schemas.get("Things").unwrap() {
+        rweb::openapi::ObjectOrReference::Object(s) => s,
+        _ => panic!(),
+    };
+    assert!(things.properties.contains_key("yarr"));
+    assert!(things.properties.contains_key("yarr0"));
+    assert!(things.properties.contains_key("tuple"));
+    assert_eq!(things.properties.get("yarr").unwrap().min_items, Some(24));
+    assert_eq!(things.properties.get("yarr").unwrap().max_items, Some(24));
+    assert_eq!(
+        things
+            .properties
+            .get("yarr")
+            .unwrap()
+            .items
+            .as_ref()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::Integer)
+    );
+    assert_eq!(things.properties.get("yarr0").unwrap().min_items, Some(0));
+    assert_eq!(things.properties.get("yarr0").unwrap().max_items, Some(0));
+    assert_eq!(
+        things
+            .properties
+            .get("yarr0")
+            .unwrap()
+            .items
+            .as_ref()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::Integer)
+    );
+    assert_eq!(things.properties.get("tuple").unwrap().min_items, Some(3));
+    assert_eq!(things.properties.get("tuple").unwrap().max_items, Some(3));
+    assert_eq!(
+        things
+            .properties
+            .get("tuple")
+            .unwrap()
+            .items
+            .as_ref()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::String)
+    );
+}


### PR DESCRIPTION
TLDR: Implements `Entity` for `[T; N]`

Now that rust stable has const generics, it is possible to provide trait implementations for fixed size arrays.

The PR can't proceed until addition of `minItems` and `maxItems` to the schema.