### PR TITLE
CI - build & test  everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          cargo test
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features


### PR DESCRIPTION
TLDR: Run cargo `build` and `test` with `--all-features` so that OpenAPI is tested as well.

That said #67 would still be missed even with this CI present, as integration tests are compiled with the same set of dependencies as the crate itself (see CI run succeeding on pre-#69 fix).

Further improvements to rigorous testing will need be introduced to handle that properly - a dependent sub-crate for some macro tests, and a OpenAPI schema validity checker to actually assert validity of generated spec on all tests, why not.