### PR TITLE
Schema components further fixes and improvements

### DIFF
--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -359,12 +359,16 @@ where
         let s = T::describe();
         if !s.ref_path.is_empty() {
             let cn = &s.ref_path[("#/components/schemas/".len())..];
-            if let Some((_, sc)) = v.iter().find(|(path, _)| path == cn) {
-                let mut sc = sc.clone();
-                sc.ref_path = Cow::Owned(format!("{}_Opt", s.ref_path));
-                sc.nullable = Some(true);
-                v.push((Cow::Owned(format!("{}_Opt", cn)), sc));
-            }
+            v.push((
+                Cow::Owned(format!("{}_Opt", cn)),
+                Schema {
+                    nullable: Some(true),
+                    one_of: vec![ObjectOrReference::Ref {
+                        ref_path: s.ref_path,
+                    }],
+                    ..Default::default()
+                },
+            ));
         }
         v
     }

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -366,9 +366,7 @@ where
                 Cow::Owned(format!("{}_Opt", cn)),
                 Schema {
                     nullable: Some(true),
-                    one_of: vec![ObjectOrReference::Ref {
-                        ref_path: s.ref_path,
-                    }],
+                    one_of: vec![ObjectOrReference::Object(s)],
                     ..Default::default()
                 },
             ));

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -308,86 +308,6 @@ impl<T: Entity> Entity for HashMap<String, T> {
     }
 }
 
-impl<T: Entity> Entity for HashMap<Arc<String>, T> {
-    fn describe() -> Schema {
-        <HashMap<String, T> as Entity>::describe()
-    }
-
-    fn describe_components() -> Components {
-        <HashMap<String, T> as Entity>::describe_components()
-    }
-}
-
-impl<T: Entity> Entity for HashMap<Cow<'_, String>, T> {
-    fn describe() -> Schema {
-        <HashMap<String, T> as Entity>::describe()
-    }
-
-    fn describe_components() -> Components {
-        <HashMap<String, T> as Entity>::describe_components()
-    }
-}
-
-impl<T: Entity> Entity for BTreeMap<String, T> {
-    fn describe() -> Schema {
-        <HashMap<String, T> as Entity>::describe()
-    }
-
-    fn describe_components() -> Components {
-        <HashMap<String, T> as Entity>::describe_components()
-    }
-}
-
-impl<T: Entity> Entity for BTreeMap<Arc<String>, T> {
-    fn describe() -> Schema {
-        <BTreeMap<String, T> as Entity>::describe()
-    }
-
-    fn describe_components() -> Components {
-        <BTreeMap<String, T> as Entity>::describe_components()
-    }
-}
-
-impl<T: Entity> Entity for BTreeMap<Cow<'_, String>, T> {
-    fn describe() -> Schema {
-        <BTreeMap<String, T> as Entity>::describe()
-    }
-
-    fn describe_components() -> Components {
-        <BTreeMap<String, T> as Entity>::describe_components()
-    }
-}
-
-impl<T: Entity> Entity for IndexMap<String, T> {
-    fn describe() -> Schema {
-        <HashMap<String, T> as Entity>::describe()
-    }
-
-    fn describe_components() -> Components {
-        <HashMap<String, T> as Entity>::describe_components()
-    }
-}
-
-impl<T: Entity> Entity for IndexMap<Arc<String>, T> {
-    fn describe() -> Schema {
-        <IndexMap<String, T> as Entity>::describe()
-    }
-
-    fn describe_components() -> Components {
-        <IndexMap<String, T> as Entity>::describe_components()
-    }
-}
-
-impl<T: Entity> Entity for IndexMap<Cow<'_, String>, T> {
-    fn describe() -> Schema {
-        <IndexMap<String, T> as Entity>::describe()
-    }
-
-    fn describe_components() -> Components {
-        <IndexMap<String, T> as Entity>::describe_components()
-    }
-}
-
 impl<T: Entity> Entity for [T] {
     fn describe() -> Schema {
         let s = T::describe();
@@ -609,6 +529,86 @@ where
     #[inline(always)]
     fn describe_components() -> Components {
         <[V] as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for HashMap<Arc<String>, T> {
+    fn describe() -> Schema {
+        <HashMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <HashMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for HashMap<Cow<'_, String>, T> {
+    fn describe() -> Schema {
+        <HashMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <HashMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for BTreeMap<String, T> {
+    fn describe() -> Schema {
+        <HashMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <HashMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for BTreeMap<Arc<String>, T> {
+    fn describe() -> Schema {
+        <BTreeMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <BTreeMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for BTreeMap<Cow<'_, String>, T> {
+    fn describe() -> Schema {
+        <BTreeMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <BTreeMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for IndexMap<String, T> {
+    fn describe() -> Schema {
+        <HashMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <HashMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for IndexMap<Arc<String>, T> {
+    fn describe() -> Schema {
+        <IndexMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <IndexMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for IndexMap<Cow<'_, String>, T> {
+    fn describe() -> Schema {
+        <IndexMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <IndexMap<String, T> as Entity>::describe_components()
     }
 }
 

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -1,14 +1,14 @@
 use crate::{Form, Json, Query};
 use indexmap::IndexMap;
 pub use rweb_openapi::v3_0::*;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
 use std::{
     borrow::Cow,
     collections::{BTreeSet, HashSet, LinkedList, VecDeque},
     convert::Infallible,
 };
 use warp::{Rejection, Reply};
-use std::sync::Arc;
-use std::collections::HashMap;
 
 pub type Components = Vec<(Cow<'static, str>, Schema)>;
 
@@ -291,17 +291,81 @@ impl<T: Entity> Entity for HashMap<String, T> {
 
 impl<T: Entity> Entity for HashMap<Arc<String>, T> {
     fn describe() -> Schema {
-        Schema {
-            schema_type: Some(Type::Object),
-            additional_properties: Some(ObjectOrReference::Object(Box::new(
-                <T as Entity>::describe()
-            ))),
-            ..Default::default()
-        }
+        <HashMap<String, T> as Entity>::describe()
     }
 
     fn describe_components() -> Components {
-        <T as Entity>::describe_components()
+        <HashMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for HashMap<Cow<'_, String>, T> {
+    fn describe() -> Schema {
+        <HashMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <HashMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for BTreeMap<String, T> {
+    fn describe() -> Schema {
+        <HashMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <HashMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for BTreeMap<Arc<String>, T> {
+    fn describe() -> Schema {
+        <BTreeMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <BTreeMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for BTreeMap<Cow<'_, String>, T> {
+    fn describe() -> Schema {
+        <BTreeMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <BTreeMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for IndexMap<String, T> {
+    fn describe() -> Schema {
+        <HashMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <HashMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for IndexMap<Arc<String>, T> {
+    fn describe() -> Schema {
+        <IndexMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <IndexMap<String, T> as Entity>::describe_components()
+    }
+}
+
+impl<T: Entity> Entity for IndexMap<Cow<'_, String>, T> {
+    fn describe() -> Schema {
+        <IndexMap<String, T> as Entity>::describe()
+    }
+
+    fn describe_components() -> Components {
+        <IndexMap<String, T> as Entity>::describe_components()
     }
 }
 

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -327,17 +327,14 @@ impl<T: Entity> Entity for [T] {
         let s = T::describe();
         if !s.ref_path.is_empty() {
             let cn = &s.ref_path[("#/components/schemas/".len())..];
-            if let Some((_, sc)) = v.iter().find(|(path, _)| path == cn) {
-                let sc = sc.clone();
-                v.push((
-                    Cow::Owned(format!("{}_List", cn)),
-                    Schema {
-                        schema_type: Some(Type::Array),
-                        items: Some(Box::new(sc)),
-                        ..Default::default()
-                    },
-                ));
-            }
+            v.push((
+                Cow::Owned(format!("{}_List", cn)),
+                Schema {
+                    schema_type: Some(Type::Array),
+                    items: Some(Box::new(s)),
+                    ..Default::default()
+                },
+            ));
         }
         v
     }

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -441,6 +441,10 @@ where
 
 pub fn schema_consistent_component_name(s: &Schema) -> Result<String, &'static str> {
     if s.ref_path.is_empty() {
+        let optsuff = match s.nullable {
+            Some(true) => "_Opt",
+            _ => "",
+        };
         match s.schema_type {
             Some(Type::String) => Ok("string".to_string()),
             Some(Type::Number) => Ok("number".to_string()),
@@ -451,6 +455,7 @@ pub fn schema_consistent_component_name(s: &Schema) -> Result<String, &'static s
             )? + "_List"),
             _ => Err("anonymous types don't have component names"),
         }
+        .map(|s| s + optsuff)
     } else {
         Ok(s.ref_path[("#/components/schemas/".len())..].to_string())
     }

--- a/tests/openapi_generic_multi_struct.rs
+++ b/tests/openapi_generic_multi_struct.rs
@@ -22,8 +22,8 @@ struct GenericStruct<A, B> {
 
 #[get("/")]
 fn test_r(
-    _: Query<GenericStruct<Option<One>, u64>>,
-    _: Json<Vec<GenericStruct<Vec<Two>, Option<GenericStruct<One, One>>>>>,
+    _: Query<GenericStruct<Option<String>, u64>>,
+    _: Json<Vec<GenericStruct<Vec<Two>, Option<GenericStruct<Option<One>, One>>>>>,
 ) -> String {
     String::new()
 }
@@ -40,10 +40,11 @@ fn test_multi_generics_compile() {
     }
     assert!(schemas.contains_key("One"));
     assert!(schemas.contains_key("Two"));
+    assert!(schemas.contains_key("GenericStruct-_string_Opt_integer_-"));
     assert!(schemas.contains_key("One_Opt"));
     assert!(schemas.contains_key("One_Map"));
     assert!(schemas.contains_key("Two_List"));
-    assert!(schemas.contains_key("GenericStruct-_One_One_-_Opt"));
+    assert!(schemas.contains_key("GenericStruct-_One_Opt_One_-_Opt"));
     macro_rules! component {
         ($cn:expr) => {
             match schemas.get($cn) {


### PR DESCRIPTION
TLDR: Follow-up to #61, improving behaviour for generic impls over component subtypes

1. Schema for `Option<T>` where `T` is a component now uses `nullable` + `oneOf` linking to `T`'s component.
One _has_ to go through `oneOf` direction because if `$ref` is present at root, all other properties are ignored.
2. For `[T]`&friends fixes a bug where generated component would nest `T`'s schema directly in `items` instead of `$ref`ing to it
3. Following up #66
    1. provided additional `Map` friends implementations (`BTreeMap` & `IndexMap`), and additionally over `Cow<String>`.
    2. if `T` is a component, (just as for `Option` and `[]`,) generate component for the map with `_Map` suffix and refer to the component in `additionalProperties` 
4. Persistent component name for primitives accounts for nullability (thus usage of `Option<u64>` resulting in `u64_Opt` component where requested).
4. Extended tests for `HashMap` (components) as well as to testing use of `$ref`