### PR TITLE
Make `cargo clippy --workspace --all-features` come clean

### DIFF
--- a/examples/rejections.rs
+++ b/examples/rejections.rs
@@ -65,7 +65,7 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
     } else if let Some(DivideByZero) = err.find() {
         code = StatusCode::BAD_REQUEST;
         message = "DIVIDE_BY_ZERO";
-    } else if let Some(_) = err.find::<rweb::reject::MethodNotAllowed>() {
+    } else if err.find::<rweb::reject::MethodNotAllowed>().is_some() {
         // We can handle a specific error, here METHOD_NOT_ALLOWED,
         // and render it however we want
         code = StatusCode::METHOD_NOT_ALLOWED;

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -329,7 +329,7 @@ fn handle_fields_required(type_attrs: &[Attribute], fields: &Fields) -> Expr {
     .parse()
 }
 
-fn extract_component(attrs: &Vec<Attribute>) -> Option<String> {
+fn extract_component(attrs: &[Attribute]) -> Option<String> {
     let mut component = None;
     let mut process_nv = |nv: syn::MetaNameValue| {
         if nv.path.is_ident("component") {

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -208,14 +208,11 @@ fn extract_doc(attrs: &mut Vec<Attribute>) -> String {
                 }
             }
         } else if attr.path.is_ident("doc") {
-            match parse2::<EqStr>(attr.tokens.clone()) {
-                Ok(v) => {
-                    if !comments.is_empty() {
-                        comments.push(' ');
-                    }
-                    comments.push_str(&v.value.value());
+            if let Ok(v) = parse2::<EqStr>(attr.tokens.clone()) {
+                if !comments.is_empty() {
+                    comments.push(' ');
                 }
-                _ => {}
+                comments.push_str(&v.value.value());
             };
         }
     }

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -444,7 +444,7 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
             if data
                 .variants
                 .iter()
-                .all(|variant| variant.fields.len() == 0)
+                .all(|variant| variant.fields.is_empty())
             {
                 // c-like enums
 
@@ -511,7 +511,7 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
                             Fields::Unnamed(ref f) => {
                                 //
                                 assert!(f.unnamed.len() <= 1);
-                                if f.unnamed.len() == 0 {
+                                if f.unnamed.is_empty() {
                                     return None;
                                 }
 

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -24,9 +24,7 @@ fn get_rename_all(attrs: &[Attribute]) -> RenameRule {
             }
 
             match parse2::<Paren<KeyValue<Ident, LitStr>>>(attr.tokens.clone()).map(|v| v.inner) {
-                Ok(kv) if kv.key.to_string() == "rename_all" => {
-                    Some(kv.value.value().parse().unwrap())
-                }
+                Ok(kv) if kv.key == "rename_all" => Some(kv.value.value().parse().unwrap()),
                 _ => None,
             }
         })

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -55,7 +55,7 @@ fn get_rename(attrs: &[Attribute]) -> Option<String> {
             };
         }
 
-        return None;
+        None
     })
 }
 

--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -202,16 +202,14 @@ fn quote_mediatype(m: &MediaType) -> Expr {
 }
 
 fn quote_schema_or_ref(ros: &ObjectOrReference<Schema>) -> TokenStream {
-    match ros {
-        ObjectOrReference::Ref { ref_path: r } => r
-            .parse::<TokenStream>()
-            .expect("failed to lex path to type"),
-        ObjectOrReference::Object(schema) => match &schema.ref_path {
-            r => r
-                .parse::<TokenStream>()
-                .expect("failed to lex path to type"),
-        },
-    }
+    let r#ref = match ros {
+        ObjectOrReference::Ref { ref_path } => ref_path,
+        ObjectOrReference::Object(schema) => &schema.ref_path,
+    };
+
+    r#ref
+        .parse::<TokenStream>()
+        .expect("failed to lex path to type")
 }
 
 fn quote_location(l: Location) -> Quote {

--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -232,10 +232,12 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
 
         let var = &segment[1..segment.len() - 1];
         if let Some(ty) = find_ty(sig, var) {
-            let mut p = Parameter::default();
-            p.name = Cow::Owned(var.to_string());
-            p.location = Location::Path;
-            p.required = Some(true);
+            let p = Parameter {
+                name: var.to_string().into(),
+                location: Location::Path,
+                required: Some(true),
+                ..Parameter::default()
+            };
 
             op.parameters.push(ObjectOrReference::Object(Parameter {
                 name: Cow::Owned(var.to_string()),

--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -232,13 +232,6 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
 
         let var = &segment[1..segment.len() - 1];
         if let Some(ty) = find_ty(sig, var) {
-            let p = Parameter {
-                name: var.to_string().into(),
-                location: Location::Path,
-                required: Some(true),
-                ..Parameter::default()
-            };
-
             op.parameters.push(ObjectOrReference::Object(Parameter {
                 name: Cow::Owned(var.to_string()),
                 location: Location::Path,

--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -225,7 +225,7 @@ pub fn parse(path: &str, sig: &Signature, attrs: &mut Vec<Attribute>) -> Operati
     let mut op = Operation::default();
     let mut has_description = false;
 
-    for segment in path.split('/').filter(|&s| s != "") {
+    for segment in path.split('/').filter(|s| !s.is_empty()) {
         if !segment.starts_with('{') {
             continue;
         }

--- a/macros/src/path.rs
+++ b/macros/src/path.rs
@@ -30,7 +30,7 @@ pub fn compile(
     let path = path.value();
     assert!(path.starts_with('/'), "Path should start with /");
     assert!(
-        path.find("//").is_none(),
+        !path.contains("//"),
         "A path containing `//` doesn't make sense"
     );
 

--- a/macros/src/path.rs
+++ b/macros/src/path.rs
@@ -43,7 +43,11 @@ pub fn compile(
     // Mainly it will come from the required path in the beginning / but could also
     // come from the end / Example: #[get("/{word}")] or #[get("/{word}/")] with
     // the `/` before and after `{word}`
-    let segments: Vec<&str> = path.split('/').into_iter().filter(|&x| x != "").collect();
+    let segments: Vec<&str> = path
+        .split('/')
+        .into_iter()
+        .filter(|x| !x.is_empty())
+        .collect();
     for segment in segments {
         let expr = if segment.starts_with('{') {
             // Example if {word} we only want to extract `word` here

--- a/macros/src/route/param.rs
+++ b/macros/src/route/param.rs
@@ -27,16 +27,15 @@ pub fn compile(
                 continue;
             }
 
-            match &sig.inputs[idx] {
-                FnArg::Typed(pat) => match *pat.pat {
+            if let FnArg::Typed(pat) = &sig.inputs[idx] {
+                match *pat.pat {
                     Pat::Ident(ref i) if i.ident == name => {
                         inputs[orig_idx] = sig.inputs[idx].clone();
                         inputs[idx] = sig.inputs[orig_idx].clone();
                         path_params.insert(orig_idx);
                     }
                     _ => {}
-                },
-                _ => {}
+                }
             }
         }
     }

--- a/macros/src/route/param.rs
+++ b/macros/src/route/param.rs
@@ -145,12 +145,11 @@ pub fn compile(
                     }
 
                     // Don't add unit type to argument list
-                    match i.value() {
-                        FnArg::Typed(pat) => match &*pat.ty {
+                    if let FnArg::Typed(pat) = i.value() {
+                        match &*pat.ty {
                             Type::Tuple(tuple) if tuple.elems.is_empty() => continue,
                             _ => {}
-                        },
-                        _ => {}
+                        }
                     }
 
                     actual_inputs.push(i);

--- a/macros/src/route/param.rs
+++ b/macros/src/route/param.rs
@@ -80,7 +80,7 @@ pub fn compile(
                         panic!("rweb currently support only one attribute on a parameter")
                     }
 
-                    let attr = pat.attrs.iter().next().unwrap().clone();
+                    let attr = pat.attrs.get(0).cloned().unwrap();
                     pat.attrs = vec![];
 
                     if attr.path.is_ident("form") {

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -16,7 +16,7 @@ use warp::Reply;
 pub fn openapi_docs(spec: Spec) -> BoxedFilter<(impl Reply,)> {
     let docs_openapi = warp::path("openapi.json").map(move || warp::reply::json(&spec.to_owned()));
     let docs = warp::path("docs").map(|| {
-        return warp::reply::html(
+        warp::reply::html(
             r#"
             <!doctype html>
             <html lang="en">
@@ -47,7 +47,7 @@ pub fn openapi_docs(spec: Spec) -> BoxedFilter<(impl Reply,)> {
             </body>
             </html>
         "#,
-        );
+        )
     });
     docs.or(docs_openapi).boxed()
 }

--- a/src/openapi/builder.rs
+++ b/src/openapi/builder.rs
@@ -29,7 +29,7 @@ impl Builder {
     /// **Overrides** path prefix with given string.
     #[inline]
     pub fn prefix(mut self, path: String) -> Self {
-        assert!(path.starts_with("/"));
+        assert!(path.starts_with('/'));
         self.path_prefix = path;
 
         self

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -305,36 +305,33 @@ impl Collector {
             "Query<Enum> is invalid. Store enum as a field."
         );
 
-        match s.schema_type {
-            Some(Type::Object) => {
-                //
+        if let Some(Type::Object) = s.schema_type {
+            //
 
-                for (name, s) in s.properties {
-                    if s.properties.is_empty() {
-                        op.parameters.push(ObjectOrReference::Object(Parameter {
-                            name,
-                            location: Location::Query,
-                            description: s.description.clone(),
-                            representation: Some(ParameterRepresentation::Simple {
-                                schema: ObjectOrReference::Object(s),
-                            }),
-                            ..Default::default()
-                        }));
-                    } else {
-                        op.parameters.push(ObjectOrReference::Object(Parameter {
-                            required: Some(s.required.contains(&name)),
-                            name,
-                            location: Location::Query,
-                            description: s.description.clone(),
-                            representation: Some(ParameterRepresentation::Simple {
-                                schema: ObjectOrReference::Object(s),
-                            }),
-                            ..Default::default()
-                        }));
-                    }
+            for (name, s) in s.properties {
+                if s.properties.is_empty() {
+                    op.parameters.push(ObjectOrReference::Object(Parameter {
+                        name,
+                        location: Location::Query,
+                        description: s.description.clone(),
+                        representation: Some(ParameterRepresentation::Simple {
+                            schema: ObjectOrReference::Object(s),
+                        }),
+                        ..Default::default()
+                    }));
+                } else {
+                    op.parameters.push(ObjectOrReference::Object(Parameter {
+                        required: Some(s.required.contains(&name)),
+                        name,
+                        location: Location::Query,
+                        description: s.description.clone(),
+                        representation: Some(ParameterRepresentation::Simple {
+                            schema: ObjectOrReference::Object(s),
+                        }),
+                        ..Default::default()
+                    }));
                 }
             }
-            _ => {}
         }
     }
 


### PR DESCRIPTION
While adding `uuid` support I've noticed that `clippy` is not happy and took the liberty of fixing all the `clippy` suggestions.
I believe that these changes are trivial enough to be non-controversial. Feel free to reject this PR if you feel otherwise.
I tried to organize all of the fixes in "one-clippy-change-per-commit" manner to allow for cherry-picking if necessary.



