### PR TITLE
EnumSet support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1"
 tokio = {version = "1.2", features = ["macros", "rt-multi-thread"]}
 tokio-stream = "0.1"
 uuid = {version = "0.8", features = ["serde"], optional = true}
+enumset = {version = "1.0", features = ["serde"], optional = true}
 warp = "0.3.0"
 
 [dev-dependencies]

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -899,9 +899,6 @@ mod enumsetrepr {
 
     // A `EnumSet<T>` can be serialized as either some number, or list of strings
     // depending on the presence of `#[enumset(serialize_as_list)]` attr.
-    //
-    // Passive detection of the attribute would require _adding_ conditional derives
-    // to the derivation of `Schema` for `T` to additionally derive `Schema` for `EnumSet<T>`.
 
     impl<T: EnumSetType + Entity> Entity for EnumSet<T> {
         fn describe() -> Schema {

--- a/tests/openapi_enumset.rs
+++ b/tests/openapi_enumset.rs
@@ -1,0 +1,52 @@
+#![cfg(feature = "openapi")]
+#![cfg(feature = "enumset")]
+
+use enumset::*;
+use rweb::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(EnumSetType, Schema, Serialize, Deserialize, Debug)]
+#[schema(component = "Flagged")]
+pub enum Flagged {
+    A,
+    B,
+    C,
+}
+
+#[derive(EnumSetType, Schema, Serialize, Deserialize, Debug)]
+#[enumset(serialize_as_list)]
+#[schema(component = "Named")]
+pub enum Named {
+    A,
+    B,
+    C,
+}
+
+#[get("/")]
+fn index(_: Query<EnumSet<Flagged>>, _: Json<EnumSet<Named>>) -> String {
+    String::new()
+}
+
+#[test]
+fn description() {
+    let (spec, _) = openapi::spec().build(|| {
+        //
+        index()
+    });
+    let schemas = &spec.components.as_ref().unwrap().schemas;
+    println!("{}", serde_yaml::to_string(&schemas).unwrap());
+    macro_rules! component {
+        ($cn:expr) => {
+            match schemas.get($cn) {
+                Some(openapi::ObjectOrReference::Object(s)) => s,
+                Some(..) => panic!("Component schema can't be a reference"),
+                None => panic!("No component schema for {}", $cn),
+            }
+        };
+    }
+    let flagged = component!("Flagged_EnumSet");
+    assert_eq!(flagged.schema_type, Some(openapi::Type::Integer));
+    let named = component!("Named_EnumSet");
+    assert_eq!(named.schema_type, Some(openapi::Type::Array));
+    assert!(named.items.is_some());
+}


### PR DESCRIPTION
Added support for [`enumset`](https://crates.io/crates/enumset) crate.

`EnumSet` allows 2 serde representations - as bit flags (number) or as list of strings - controlled by `#[enumset(serialize_as_list)]` attribute. `rweb` can't detect the attribute actively, and detecting it in `derive(Schema)` won't work either (since both `rweb::Schema` and `enumset::EnumSet<T>` are in foreign crates for `impl rweb::Schema for enumset::EnumSet<T>`). Hence one has to resort to "active" representation detection via `serde_json` conversion :D
