### PR TITLE
fix: allow to disable websocket and multipart from warp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1"
 tokio = {version = "1.2", features = ["macros", "rt-multi-thread"]}
 tokio-stream = "0.1"
 uuid = {version = "0.8", features = ["serde"], optional = true}
-warp = "0.3.0"
+warp = {version = "0.3.0", default-features = false}
 
 [dev-dependencies]
 bytes = "1.0"


### PR DESCRIPTION
As default-features for warp are not disabled, it is not possible to remove websocket and multipart dependencies from warp.