### PR TITLE
fix: allow to disable websocket and multipart from warp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1"
 tokio = {version = "1.2", features = ["macros", "rt-multi-thread"]}
 tokio-stream = "0.1"
 uuid = {version = "0.8", features = ["serde"], optional = true}
-warp = "0.3.0"
+warp = {version = "0.3.0", default-features = false}
 
 [dev-dependencies]
 bytes = "1.0"

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,7 +1,11 @@
 use futures::future::ok;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+#[cfg(feature = "multipart")]
+use warp::filters::multipart;
+#[cfg(feature = "websocket")]
+use warp::filters::ws::Ws;
 use warp::{
-    filters::{multipart, ws::Ws, BoxedFilter},
+    filters::BoxedFilter,
     reply::{json, Response},
     Filter, Rejection, Reply,
 };
@@ -174,6 +178,7 @@ where
     }
 }
 
+#[cfg(feature = "websocket")]
 impl FromRequest for Ws {
     type Filter = BoxedFilter<(Ws,)>;
 
@@ -182,6 +187,7 @@ impl FromRequest for Ws {
     }
 }
 
+#[cfg(feature = "multipart")]
 impl FromRequest for multipart::FormData {
     type Filter = BoxedFilter<(Self,)>;
 


### PR DESCRIPTION
As default-features for warp are not disabled, it is not possible to remove websocket and multipart dependencies from warp.