### PR TITLE
Entity `describe` & component improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3"
 http = "0.2"
 indexmap = "1"
 rweb-macros = {version = "0.11.3", path = "./macros"}
-rweb-openapi = {version = "0.6.0", optional = true, git = "https://github.com/E-gy/rweb-openapi", branch = "component-or-inline" }
+rweb-openapi = {version = "0.6.0", optional = true}
 scoped-tls = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3"
 http = "0.2"
 indexmap = "1"
 rweb-macros = {version = "0.11.3", path = "./macros"}
-rweb-openapi = {version = "0.6.0", optional = true}
+rweb-openapi = {version = "0.7.0", optional = true}
 scoped-tls = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3"
 http = "0.2"
 indexmap = "1"
 rweb-macros = {version = "0.11.3", path = "./macros"}
-rweb-openapi = {version = "0.6.0", optional = true}
+rweb-openapi = {version = "0.6.0", optional = true, git = "https://github.com/E-gy/rweb-openapi", branch = "component-or-inline" }
 scoped-tls = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -156,11 +156,13 @@ fn quote_response(r: &Response) -> Expr {
                 {
                     (|| {
                         let mut resp =
-                            <aschema_v as rweb::openapi::ResponseEntity>::describe_responses()
-                                .into_iter()
-                                .next()
-                                .map(|(_, r)| r)
-                                .unwrap_or_else(|| Default::default());
+                            <aschema_v as rweb::openapi::ResponseEntity>::describe_responses(
+                                __collector.components(),
+                            )
+                            .into_iter()
+                            .next()
+                            .map(|(_, r)| r)
+                            .unwrap_or_else(|| Default::default());
                         resp.description = rweb::rt::Cow::Borrowed(description_v);
                         resp
                     })()

--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -29,17 +29,17 @@ mod case;
 mod derive;
 
 macro_rules! quote_str_indexmap {
-	($map:expr, $quot:ident) => {
-		$map.iter()
+    ($map:expr, $quot:ident) => {
+        $map.iter()
         .map(|(nam, t)| {
-			let tq = $quot(t);
+            let tq = $quot(t);
             Pair::Punctuated(
                 q!(Vars { nam, tq }, { rweb::rt::Cow::Borrowed(nam) => tq }),
                 Default::default(),
             )
         })
         .collect();
-	};
+    };
 }
 
 pub fn quote_op(op: Operation) -> Expr {

--- a/macros/src/openapi/mod.rs
+++ b/macros/src/openapi/mod.rs
@@ -135,9 +135,7 @@ fn quote_parameter(param: &ObjectOrReference<Parameter>) -> Expr {
                 location: location_v,
                 required: required_v,
                 representation: Some(rweb::openapi::ParameterRepresentation::Simple {
-                    schema: rweb::openapi::ObjectOrReference::Object(
-                        <Type as rweb::openapi::Entity>::describe(),
-                    ),
+                    schema: <Type as rweb::openapi::Entity>::describe(__collector.components()),
                 }),
                 ..Default::default()
             })

--- a/src/openapi/builder.rs
+++ b/src/openapi/builder.rs
@@ -48,7 +48,7 @@ impl Builder {
         let cell = RefCell::new(collector);
 
         let ret = COLLECTOR.set(&cell, || op());
-        let mut spec = cell.into_inner().spec;
+        let mut spec = cell.into_inner().spec();
         spec.openapi = "3.0.1".into();
         (spec, ret)
     }

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -447,7 +447,7 @@ where
             desc
         } else {
             let mut schema = schema.clone();
-            schema.nullable = Some(false);
+            schema.nullable = Some(true);
             match desc {
                 ComponentOrInlineSchema::Component { .. } => {
                     comp_d.describe_component(&Self::type_name(), |_| schema)

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -170,19 +170,19 @@ pub trait ResponseEntity: Entity {
 
 /// Implements entity by another entity
 macro_rules! delegate_entity {
-	// full paths (with `::`) not supported
-	( $T:tt $(< $( $tlt:tt $(< $( $tltt:tt ),+ >)? ),+ >)? => $D:tt $(< $( $plt:tt $(< $( $pltt:tt ),+ >)? ),+ >)? ) => {
-		impl Entity for $T $(< $( $tlt $(< $( $tltt ),+ >)? ),+ >)? {
-			fn type_name() -> Cow<'static, str> {
-				<$D $(< $( $plt $(< $( $pltt ),+ >)? ),+ >)? as Entity>::type_name()
-			}
-			fn describe(d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
-				<$D $(< $( $plt $(< $( $pltt ),+ >)? ),+ >)? as Entity>::describe(d)
-			}
-		}
+    // full paths (with `::`) not supported
+    ( $T:tt $(< $( $tlt:tt $(< $( $tltt:tt ),+ >)? ),+ >)? => $D:tt $(< $( $plt:tt $(< $( $pltt:tt ),+ >)? ),+ >)? ) => {
+        impl Entity for $T $(< $( $tlt $(< $( $tltt ),+ >)? ),+ >)? {
+            fn type_name() -> Cow<'static, str> {
+                <$D $(< $( $plt $(< $( $pltt ),+ >)? ),+ >)? as Entity>::type_name()
+            }
+            fn describe(d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+                <$D $(< $( $plt $(< $( $pltt ),+ >)? ),+ >)? as Entity>::describe(d)
+            }
+        }
     };
-	// Doesn't work with `?Sized` :(
-	( < $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ > $T:tt $(< $( $tlt:tt $(< $( $tltt:tt ),+ >)? ),+ >)? => $D:tt $(< $( $plt:tt $(< $( $pltt:tt ),+ >)? ),+ >)? ) => {
+    // Doesn't work with `?Sized` :(
+    ( < $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ > $T:tt $(< $( $tlt:tt $(< $( $tltt:tt ),+ >)? ),+ >)? => $D:tt $(< $( $plt:tt $(< $( $pltt:tt ),+ >)? ),+ >)? ) => {
         impl < $( $lt $( : $clt $(+ $dlt )* )? ),+ > Entity for $T $(< $( $tlt $(< $( $tltt ),+ >)? ),+ >)? {
             fn type_name() -> Cow<'static, str> {
                 <$D $(< $( $plt $(< $( $pltt ),+ >)? ),+ >)? as Entity>::type_name()
@@ -211,18 +211,18 @@ impl Entity for () {
 macro_rules! integer {
     ($T:ty) => {
         impl Entity for $T {
-			fn type_name() -> Cow<'static, str> {
-				Cow::Borrowed("integer")
-			}
+            fn type_name() -> Cow<'static, str> {
+                Cow::Borrowed("integer")
+            }
             #[inline]
             fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
                 ComponentOrInlineSchema::Inline(Schema {
                     schema_type: Some(Type::Integer),
-					minimum: if <$T>::MIN == 0 {
-						Some(serde_json::json!(0))
-					} else {
-						None
-					},
+                    minimum: if <$T>::MIN == 0 {
+                        Some(serde_json::json!(0))
+                    } else {
+                        None
+                    },
                     ..Default::default()
                 })
             }

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -212,7 +212,7 @@ macro_rules! integer {
     ($T:ty) => {
         impl Entity for $T {
 			fn type_name() -> Cow<'static, str> {
-				Cow::Borrowed("int")
+				Cow::Borrowed("integer")
 			}
             #[inline]
             fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -374,148 +374,61 @@ where
 }
 
 impl<T: Entity> Entity for HashMap<String, T> {
-    fn describe() -> Schema {
-        let s = <T as Entity>::describe();
-        if s.ref_path.is_empty() {
-            Schema {
-                schema_type: Some(Type::Object),
-                additional_properties: Some(ObjectOrReference::Object(Box::new(s))),
-                ..Default::default()
-            }
-        } else {
-            Schema {
-                ref_path: Cow::Owned(format!("{}_Map", s.ref_path)),
-                ..Default::default()
-            }
-        }
+    fn type_name() -> Cow<'static, str> {
+        Cow::Owned(format!("Map-string_{}-", T::type_name()))
     }
 
-    fn describe_components() -> Components {
-        let mut v = T::describe_components();
-        let s = T::describe();
-        if !s.ref_path.is_empty() {
-            let cn = &s.ref_path[("#/components/schemas/".len())..];
-            v.push((
-                Cow::Owned(format!("{}_Map", cn)),
-                Schema {
-                    schema_type: Some(Type::Object),
-                    additional_properties: Some(ObjectOrReference::Object(Box::new(s))),
-                    ..Default::default()
-                },
-            ));
-        }
-        v
+    fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        ComponentOrInlineSchema::Inline(Schema {
+            schema_type: Some(Type::Object),
+            additional_properties: Some(Box::new(T::describe(comp_d))),
+            ..Default::default()
+        })
     }
 }
 
 impl<T: Entity> Entity for [T] {
-    fn describe() -> Schema {
-        let s = T::describe();
-        if s.ref_path.is_empty() {
-            Schema {
-                schema_type: Some(Type::Array),
-                items: Some(Box::new(s)),
-                ..Default::default()
-            }
-        } else {
-            Schema {
-                ref_path: Cow::Owned(format!("{}_List", s.ref_path)),
-                ..Default::default()
-            }
-        }
+    fn type_name() -> Cow<'static, str> {
+        Cow::Owned(format!("{}_List", T::type_name()))
     }
 
-    fn describe_components() -> Components {
-        let mut v = T::describe_components();
-        let s = T::describe();
-        if !s.ref_path.is_empty() {
-            let cn = &s.ref_path[("#/components/schemas/".len())..];
-            v.push((
-                Cow::Owned(format!("{}_List", cn)),
-                Schema {
-                    schema_type: Some(Type::Array),
-                    items: Some(Box::new(s)),
-                    ..Default::default()
-                },
-            ));
-        }
-        v
+    fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        ComponentOrInlineSchema::Inline(Schema {
+            schema_type: Some(Type::Array),
+            items: Some(Box::new(T::describe(comp_d))),
+            ..Default::default()
+        })
     }
 }
 
 impl<T: Entity, const N: usize> Entity for [T; N] {
-    fn describe() -> Schema {
-        let s = T::describe();
-        if s.ref_path.is_empty() {
-            Schema {
-                schema_type: Some(Type::Array),
-                items: Some(Box::new(s)),
-                min_items: Some(N),
-                max_items: Some(N),
-                ..Default::default()
-            }
-        } else {
-            Schema {
-                ref_path: Cow::Owned(format!("{}_Array_{}", s.ref_path, N)),
-                ..Default::default()
-            }
-        }
+    fn type_name() -> Cow<'static, str> {
+        Cow::Owned(format!("{}_Array_{}", T::type_name(), N))
     }
 
-    fn describe_components() -> Components {
-        let mut v = T::describe_components();
-        let s = T::describe();
-        if !s.ref_path.is_empty() {
-            let cn = &s.ref_path[("#/components/schemas/".len())..];
-            v.push((
-                Cow::Owned(format!("{}_Array_{}", cn, N)),
-                Schema {
-                    schema_type: Some(Type::Array),
-                    items: Some(Box::new(s)),
-                    min_items: Some(N),
-                    max_items: Some(N),
-                    ..Default::default()
-                },
-            ));
-        }
-        v
+    fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        ComponentOrInlineSchema::Inline(Schema {
+            schema_type: Some(Type::Array),
+            items: Some(Box::new(T::describe(comp_d))),
+            min_items: Some(N),
+            max_items: Some(N),
+            ..Default::default()
+        })
     }
 }
 
 impl<T: Entity> Entity for BTreeSet<T> {
-    fn describe() -> Schema {
-        let s = T::describe();
-        if s.ref_path.is_empty() {
-            Schema {
-                schema_type: Some(Type::Array),
-                items: Some(Box::new(s)),
-                unique_items: Some(true),
-                ..Default::default()
-            }
-        } else {
-            Schema {
-                ref_path: Cow::Owned(format!("{}_Set", s.ref_path)),
-                ..Default::default()
-            }
-        }
+    fn type_name() -> Cow<'static, str> {
+        Cow::Owned(format!("{}_Set", T::type_name()))
     }
 
-    fn describe_components() -> Components {
-        let mut v = T::describe_components();
-        let s = T::describe();
-        if !s.ref_path.is_empty() {
-            let cn = &s.ref_path[("#/components/schemas/".len())..];
-            v.push((
-                Cow::Owned(format!("{}_Set", cn)),
-                Schema {
-                    schema_type: Some(Type::Array),
-                    items: Some(Box::new(s)),
-                    unique_items: Some(true),
-                    ..Default::default()
-                },
-            ));
-        }
-        v
+    fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        ComponentOrInlineSchema::Inline(Schema {
+            schema_type: Some(Type::Array),
+            items: Some(Box::new(T::describe(comp_d))),
+            unique_items: Some(true),
+            ..Default::default()
+        })
     }
 }
 
@@ -523,31 +436,25 @@ impl<T> Entity for Option<T>
 where
     T: Entity,
 {
-    fn describe() -> Schema {
-        let mut s = T::describe();
-        if s.ref_path.is_empty() {
-            s.nullable = Some(true);
-        } else {
-            s.ref_path = Cow::Owned(format!("{}_Opt", s.ref_path))
-        }
-        s
+    fn type_name() -> Cow<'static, str> {
+        Cow::Owned(format!("{}_Opt", T::type_name()))
     }
 
-    fn describe_components() -> Components {
-        let mut v = T::describe_components();
-        let s = T::describe();
-        if !s.ref_path.is_empty() {
-            let cn = &s.ref_path[("#/components/schemas/".len())..];
-            v.push((
-                Cow::Owned(format!("{}_Opt", cn)),
-                Schema {
-                    nullable: Some(true),
-                    one_of: vec![ObjectOrReference::Object(s)],
-                    ..Default::default()
-                },
-            ));
+    fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        let desc = T::describe(comp_d);
+        let schema = comp_d.get_unpack(&desc);
+        if schema.nullable == Some(true) {
+            desc
+        } else {
+            let mut schema = schema.clone();
+            schema.nullable = Some(false);
+            match desc {
+                ComponentOrInlineSchema::Component { .. } => {
+                    comp_d.describe_component(&Self::type_name(), |_| schema)
+                }
+                ComponentOrInlineSchema::Inline(_) => ComponentOrInlineSchema::Inline(schema),
+            }
         }
-        v
     }
 }
 
@@ -605,35 +512,32 @@ where
     T: Entity,
     E: Entity,
 {
-    fn describe() -> Schema {
-        Schema {
+    fn type_name() -> Cow<'static, str> {
+        Cow::Owned(format!("Result-{}_{}-", T::type_name(), E::type_name()))
+    }
+
+    fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        ComponentOrInlineSchema::Inline(Schema {
             one_of: vec![
-                ObjectOrReference::Object(Schema {
+                ComponentOrInlineSchema::Inline(Schema {
                     schema_type: Some(Type::Object),
                     properties: indexmap::indexmap! {
-                        Cow::Borrowed("Ok") => T::describe(),
+                        Cow::Borrowed("Ok") => T::describe(comp_d),
                     },
                     required: vec![Cow::Borrowed("Ok")],
                     ..Default::default()
                 }),
-                ObjectOrReference::Object(Schema {
+                ComponentOrInlineSchema::Inline(Schema {
                     schema_type: Some(Type::Object),
                     properties: indexmap::indexmap! {
-                        Cow::Borrowed("Err") => E::describe(),
+                        Cow::Borrowed("Err") => E::describe(comp_d),
                     },
                     required: vec![Cow::Borrowed("Err")],
                     ..Default::default()
                 }),
             ],
             ..Default::default()
-        }
-    }
-
-    fn describe_components() -> Components {
-        let mut buf = vec![];
-        buf.extend(T::describe_components());
-        buf.extend(E::describe_components());
-        buf
+        })
     }
 }
 
@@ -771,12 +675,16 @@ impl ResponseEntity for dyn Reply {
 
 #[cfg(feature = "uuid")]
 impl Entity for uuid::Uuid {
-    fn describe() -> Schema {
-        Schema {
+    fn type_name() -> Cow<'static, str> {
+        Cow::Borrowed("uuid")
+    }
+
+    fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        ComponentOrInlineSchema::Inline(Schema {
             schema_type: Some(Type::String),
-            format: "uuid".into(),
+            format: Self::type_name(),
             ..Default::default()
-        }
+        })
     }
 }
 
@@ -802,104 +710,64 @@ mod enumsetrepr {
     // depending on the presence of `#[enumset(serialize_as_list)]` attr.
 
     impl<T: EnumSetType + Entity> Entity for EnumSet<T> {
-        fn describe() -> Schema {
-            let s = T::describe();
-            if s.ref_path.is_empty() {
-                match EnumSetRepr::detect::<T>() {
-                    EnumSetRepr::BitFlags(_) => Schema {
-                        schema_type: Some(Type::Integer),
-                        description: s.description,
-                        ..Default::default()
-                    },
-                    EnumSetRepr::List(_) => Schema {
-                        schema_type: Some(Type::Array),
-                        items: Some(Box::new(s)),
-                        ..Default::default()
-                    },
-                }
-            } else {
-                Schema {
-                    ref_path: Cow::Owned(format!("{}_EnumSet", s.ref_path)),
-                    ..Default::default()
-                }
-            }
+        fn type_name() -> Cow<'static, str> {
+            Cow::Owned(format!("{}_EnumSet", T::type_name()))
         }
 
-        fn describe_components() -> Components {
-            let mut v = T::describe_components();
-            let s = T::describe();
-            if !s.ref_path.is_empty() {
-                let cn = &s.ref_path[("#/components/schemas/".len())..];
-                v.push((
-                    Cow::Owned(format!("{}_EnumSet", cn)),
-                    match EnumSetRepr::detect::<T>() {
-                        EnumSetRepr::BitFlags(_) => Schema {
-                            schema_type: Some(Type::Integer),
-                            description: s.description,
-                            ..Default::default()
-                        },
-                        EnumSetRepr::List(_) => Schema {
-                            schema_type: Some(Type::Array),
-                            items: Some(Box::new(s)),
-                            ..Default::default()
-                        },
-                    },
-                ));
-            }
-            v
+        fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+            let t = T::describe(comp_d);
+            let s = comp_d.get_unpack(&t);
+            ComponentOrInlineSchema::Inline(match EnumSetRepr::detect::<T>() {
+                EnumSetRepr::BitFlags(_) => Schema {
+                    schema_type: Some(Type::Integer),
+                    description: s.description.clone(),
+                    ..Default::default()
+                },
+                EnumSetRepr::List(_) => Schema {
+                    schema_type: Some(Type::Array),
+                    items: Some(Box::new(t)),
+                    ..Default::default()
+                },
+            })
         }
     }
 }
 
 #[cfg(feature = "chrono")]
 mod chrono_impls {
-    use chrono::TimeZone;
+    use chrono::*;
 
     use super::*;
 
-    impl Entity for chrono::NaiveDateTime {
-        fn describe() -> Schema {
-            Schema {
+    impl Entity for NaiveDateTime {
+        fn type_name() -> Cow<'static, str> {
+            Cow::Borrowed("date-time")
+        }
+
+        fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+            ComponentOrInlineSchema::Inline(Schema {
                 schema_type: Some(Type::String),
-                format: "date-time".into(),
+                format: Self::type_name(),
                 ..Default::default()
-            }
+            })
         }
     }
+
+    delegate_entity!(<T: TimeZone> DateTime<T> => NaiveDateTime);
 
     impl Entity for chrono::NaiveDate {
-        fn describe() -> Schema {
-            Schema {
+        fn type_name() -> Cow<'static, str> {
+            Cow::Borrowed("date")
+        }
+
+        fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+            ComponentOrInlineSchema::Inline(Schema {
                 schema_type: Some(Type::String),
-                format: "date".into(),
+                format: Self::type_name(),
                 ..Default::default()
-            }
+            })
         }
     }
 
-    impl<T> Entity for chrono::Date<T>
-    where
-        T: TimeZone,
-    {
-        fn describe() -> Schema {
-            Schema {
-                schema_type: Some(Type::String),
-                format: "date".into(),
-                ..Default::default()
-            }
-        }
-    }
-
-    impl<T> Entity for chrono::DateTime<T>
-    where
-        T: TimeZone,
-    {
-        fn describe() -> Schema {
-            Schema {
-                schema_type: Some(Type::String),
-                format: "date-time".into(),
-                ..Default::default()
-            }
-        }
-    }
+    delegate_entity!(<T: TimeZone> Date<T> => NaiveDate);
 }

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -146,11 +146,22 @@ impl ComponentDescriptor {
 /// }
 /// ```
 pub trait Entity {
-    fn describe() -> Schema;
+    /// String uniquely identifying this type, respecting component naming pattern.
+    ///
+    /// If this type is a component, this is the component's name.
+    ///
+    /// Even if this type is not a component, this is necessary for assembling names of generic components
+    /// parameterized on underlying types.
+    ///
+    /// # Returns
+    /// Name of this type, respecting `^[a-zA-Z0-9\.\-_]+$` regex.
+    ///
+    /// # Panics
+    /// Panic if you decide that this type must not be used for generic parameterization of components.
+    fn type_name() -> Cow<'static, str>;
 
-    fn describe_components() -> Components {
-        Default::default()
-    }
+    /// Describe this entity, and the components it (may) requires.
+    fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema;
 }
 
 /// This should be implemented only for types that know how it should be

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -9,8 +9,6 @@ use std::{
 };
 use warp::{Rejection, Reply};
 
-pub type Components = Vec<(Cow<'static, str>, Schema)>;
-
 pub type Responses = IndexMap<Cow<'static, str>, Response>;
 
 #[derive(Debug)]

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -212,7 +212,11 @@ macro_rules! integer {
     ($T:ty) => {
         impl Entity for $T {
             fn type_name() -> Cow<'static, str> {
-                Cow::Borrowed("integer")
+                if <$T>::MIN == 0 {
+                    Cow::Borrowed("uinteger")
+                } else {
+                    Cow::Borrowed("integer")
+                }
             }
             #[inline]
             fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -218,6 +218,11 @@ macro_rules! integer {
             fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
                 ComponentOrInlineSchema::Inline(Schema {
                     schema_type: Some(Type::Integer),
+					minimum: if <$T>::MIN == 0 {
+						Some(serde_json::json!(0))
+					} else {
+						None
+					},
                     ..Default::default()
                 })
             }

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -716,7 +716,7 @@ impl Entity for uuid::Uuid {
         Cow::Borrowed("uuid")
     }
 
-    fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+    fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
         ComponentOrInlineSchema::Inline(Schema {
             schema_type: Some(Type::String),
             format: Self::type_name(),
@@ -781,7 +781,7 @@ mod chrono_impls {
             Cow::Borrowed("date-time")
         }
 
-        fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
             ComponentOrInlineSchema::Inline(Schema {
                 schema_type: Some(Type::String),
                 format: Self::type_name(),
@@ -797,7 +797,7 @@ mod chrono_impls {
             Cow::Borrowed("date")
         }
 
-        fn describe(comp_d: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
             ComponentOrInlineSchema::Inline(Schema {
                 schema_type: Some(Type::String),
                 format: Self::type_name(),

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -387,6 +387,15 @@ impl Collector {
     }
 
     pub fn add_scheme<T>() {}
+
+    fn spec(self) -> Spec {
+        let mut spec = self.spec;
+        spec.components
+            .get_or_insert_with(Default::default)
+            .schemas
+            .extend(self.components.build());
+        spec
+    }
 }
 
 fn new() -> Collector {

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -234,6 +234,12 @@ pub struct Collector {
 }
 
 impl Collector {
+    /// Method used by `#[op]`
+    #[doc(hidden)]
+    pub fn components(&mut self) -> &mut ComponentDescriptor {
+        &mut self.components
+    }
+
     /// Method used by `#[router]`.
     #[doc(hidden)]
     pub fn with_appended_prefix<F, Ret>(

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -211,7 +211,7 @@
 
 pub use self::{
     builder::{spec, Builder},
-    entity::{Components, Entity, ResponseEntity, Responses},
+    entity::{ComponentDescriptor, Entity, ResponseEntity, Responses},
 };
 use crate::FromRequest;
 use http::Method;
@@ -228,6 +228,7 @@ scoped_thread_local!(static COLLECTOR: RefCell<Collector>);
 #[derive(Debug)]
 pub struct Collector {
     spec: Spec,
+    components: ComponentDescriptor,
     path_prefix: String,
     tags: Vec<Cow<'static, str>>,
 }
@@ -262,14 +263,12 @@ impl Collector {
     }
 
     pub fn add_request_type_to<T: FromRequest + Entity>(&mut self, op: &mut Operation) {
-        self.add_components(T::describe_components());
-
         if T::is_body() {
             if op.request_body.is_some() {
                 panic!("Multiple body detected");
             }
 
-            let s = T::describe();
+            let s = T::describe(&mut self.components);
 
             let mut content = IndexMap::new();
 
@@ -277,7 +276,7 @@ impl Collector {
             content.insert(
                 Cow::Borrowed(T::content_type()),
                 MediaType {
-                    schema: Some(ObjectOrReference::Object(s)),
+                    schema: Some(s),
                     examples: None,
                     encoding: Default::default(),
                 },
@@ -298,46 +297,29 @@ impl Collector {
     fn add_query_type_to<T: FromRequest + Entity>(&mut self, op: &mut Operation) {
         debug_assert!(T::is_query());
 
-        let s = T::describe();
+        let s = T::describe(&mut self.components);
+        let s = self.components.get_unpack(&s);
 
-        assert!(
-            s.enum_values.is_empty(),
-            "Query<Enum> is invalid. Store enum as a field."
+        assert_eq!(
+            Some(Type::Object),
+            s.schema_type,
+            "Query<[not object]> is invalid. Store [not object] as a field."
         );
 
-        if let Some(Type::Object) = s.schema_type {
-            //
-
-            for (name, s) in s.properties {
-                if s.properties.is_empty() {
-                    op.parameters.push(ObjectOrReference::Object(Parameter {
-                        name,
-                        location: Location::Query,
-                        description: s.description.clone(),
-                        representation: Some(ParameterRepresentation::Simple {
-                            schema: ObjectOrReference::Object(s),
-                        }),
-                        ..Default::default()
-                    }));
-                } else {
-                    op.parameters.push(ObjectOrReference::Object(Parameter {
-                        required: Some(s.required.contains(&name)),
-                        name,
-                        location: Location::Query,
-                        description: s.description.clone(),
-                        representation: Some(ParameterRepresentation::Simple {
-                            schema: ObjectOrReference::Object(s),
-                        }),
-                        ..Default::default()
-                    }));
-                }
-            }
+        for (name, ps) in &s.properties {
+            op.parameters.push(ObjectOrReference::Object(Parameter {
+                name: name.clone(),
+                location: Location::Query,
+                required: Some(s.required.contains(name)),
+                representation: Some(ParameterRepresentation::Simple { schema: ps.clone() }),
+                ..Default::default()
+            }));
         }
     }
 
     pub fn add_response_to<T: ResponseEntity>(&mut self, op: &mut Operation) {
-        self.add_components(T::describe_components());
-        let mut responses = T::describe_responses();
+        // T::describe(&mut self.components);
+        let mut responses = T::describe_responses(&mut self.components);
         for (code, mut resp) in &mut responses {
             if let Some(ex_resp) = op.responses.remove(code) {
                 if !ex_resp.description.is_empty() {
@@ -346,20 +328,6 @@ impl Collector {
             }
         }
         op.responses.extend(responses);
-    }
-
-    fn add_components(&mut self, components: Components) {
-        for (k, s) in components {
-            if self.spec.components.is_none() {
-                self.spec.components = Some(Default::default());
-            }
-            self.spec
-                .components
-                .as_mut()
-                .unwrap()
-                .schemas
-                .insert(k, ObjectOrReference::Object(s));
-        }
     }
 
     #[doc(hidden)]
@@ -418,6 +386,7 @@ impl Collector {
 fn new() -> Collector {
     Collector {
         spec: Default::default(),
+        components: ComponentDescriptor::new(),
         path_prefix: Default::default(),
         tags: vec![],
     }
@@ -435,28 +404,6 @@ where
         })
     } else {
         op(None)
-    }
-}
-
-pub fn schema_consistent_component_name(s: &Schema) -> Result<String, &'static str> {
-    if s.ref_path.is_empty() {
-        let optsuff = match s.nullable {
-            Some(true) => "_Opt",
-            _ => "",
-        };
-        match s.schema_type {
-            Some(Type::String) => Ok("string".to_string()),
-            Some(Type::Number) => Ok("number".to_string()),
-            Some(Type::Integer) => Ok("integer".to_string()),
-            Some(Type::Boolean) => Ok("boolean".to_string()),
-            Some(Type::Array) => Ok(schema_consistent_component_name(
-                s.items.as_ref().ok_or("array types must declare `items`")?,
-            )? + "_List"),
-            _ => Err("anonymous types don't have component names"),
-        }
-        .map(|s| s + optsuff)
-    } else {
-        Ok(s.ref_path[("#/components/schemas/".len())..].to_string())
     }
 }
 

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -193,7 +193,7 @@
 //! }
 //!
 //! impl openapi::ResponseEntity for Error {
-//!     fn describe_responses() -> openapi::Responses {
+//!     fn describe_responses(_: &mut openapi::ComponentDescriptor) -> openapi::Responses {
 //!         let mut map = IndexMap::new();
 //!
 //!         map.insert(

--- a/tests/openapi_arr_length.rs
+++ b/tests/openapi_arr_length.rs
@@ -27,61 +27,40 @@ fn test_skip() {
         rweb::openapi::ObjectOrReference::Object(s) => s,
         _ => panic!(),
     };
+    macro_rules! unpack {
+        ($opt:expr) => {
+            $opt.unwrap().unwrap().unwrap()
+        };
+    }
+    macro_rules! prop {
+        ($prop:expr) => {
+            unpack!(things.properties.get($prop))
+        };
+    }
     assert!(things.properties.contains_key("yarr"));
     assert!(things.properties.contains_key("yarr0"));
     assert!(things.properties.contains_key("tuple"));
-    assert_eq!(things.properties.get("yarr").unwrap().min_items, Some(24));
-    assert_eq!(things.properties.get("yarr").unwrap().max_items, Some(24));
+    assert_eq!(prop!("yarr").min_items, Some(24));
+    assert_eq!(prop!("yarr").max_items, Some(24));
     assert_eq!(
-        things
-            .properties
-            .get("yarr")
-            .unwrap()
-            .items
-            .as_ref()
-            .unwrap()
-            .schema_type,
+        unpack!(prop!("yarr").items.as_ref()).schema_type,
         Some(openapi::Type::Integer)
     );
-    assert_eq!(things.properties.get("yarr0").unwrap().min_items, Some(0));
-    assert_eq!(things.properties.get("yarr0").unwrap().max_items, Some(0));
+    assert_eq!(prop!("yarr0").min_items, Some(0));
+    assert_eq!(prop!("yarr0").max_items, Some(0));
     assert_eq!(
-        things
-            .properties
-            .get("yarr0")
-            .unwrap()
-            .items
-            .as_ref()
-            .unwrap()
-            .schema_type,
+        unpack!(prop!("yarr0").items.as_ref()).schema_type,
         Some(openapi::Type::Integer)
     );
-    assert_eq!(things.properties.get("tuple").unwrap().min_items, Some(3));
-    assert_eq!(things.properties.get("tuple").unwrap().max_items, Some(3));
+    assert_eq!(prop!("tuple").min_items, Some(3));
+    assert_eq!(prop!("tuple").max_items, Some(3));
     assert_eq!(
-        things
-            .properties
-            .get("tuple")
-            .unwrap()
-            .items
-            .as_ref()
-            .unwrap()
-            .schema_type,
+        unpack!(prop!("tuple").items.as_ref()).schema_type,
         Some(openapi::Type::String)
     );
+    assert_eq!(prop!("set").unique_items, Some(true));
     assert_eq!(
-        things.properties.get("set").unwrap().unique_items,
-        Some(true)
-    );
-    assert_eq!(
-        things
-            .properties
-            .get("set")
-            .unwrap()
-            .items
-            .as_ref()
-            .unwrap()
-            .schema_type,
+        unpack!(prop!("set").items.as_ref()).schema_type,
         Some(openapi::Type::String)
     );
 }

--- a/tests/openapi_description_example.rs
+++ b/tests/openapi_description_example.rs
@@ -37,9 +37,9 @@ fn test_description_example() {
     };
     println!("{}", serde_yaml::to_string(&schema).unwrap());
     for (_, p) in &schema.properties {
-        assert_eq!(p.description, "a description");
+        assert_eq!(p.unwrap().unwrap().description, "a description");
         assert_eq!(
-            p.example,
+            p.unwrap().unwrap().example,
             Some(serde_json::from_str("\"an example\"").unwrap())
         );
     }

--- a/tests/openapi_generic_multi_struct.rs
+++ b/tests/openapi_generic_multi_struct.rs
@@ -39,7 +39,7 @@ fn test_multi_generics_compile() {
     }
     assert!(schemas.contains_key("One"));
     assert!(schemas.contains_key("Two"));
-    assert!(schemas.contains_key("GenericStruct-string_Opt_integer-"));
+    assert!(schemas.contains_key("GenericStruct-string_Opt_uinteger-"));
     assert!(schemas.contains_key("One_Opt"));
     assert!(schemas.contains_key("GenericStruct-One_Opt_One-_Opt"));
     /*macro_rules! component {

--- a/tests/openapi_generic_multi_struct.rs
+++ b/tests/openapi_generic_multi_struct.rs
@@ -37,14 +37,14 @@ fn test_multi_generics_compile() {
             .chars()
             .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '-'))
     }
-    assert!(schemas.contains_key("One"));
+    /*assert!(schemas.contains_key("One"));
     assert!(schemas.contains_key("Two"));
     assert!(schemas.contains_key("GenericStruct-_string_Opt_integer_-"));
     assert!(schemas.contains_key("One_Opt"));
     assert!(schemas.contains_key("One_Map"));
     assert!(schemas.contains_key("Two_List"));
     assert!(schemas.contains_key("GenericStruct-_One_Opt_One_-_Opt"));
-    /*macro_rules! component {
+    macro_rules! component {
         ($cn:expr) => {
             match schemas.get($cn) {
                 Some(ObjectOrReference::Object(s)) => s,

--- a/tests/openapi_generic_multi_struct.rs
+++ b/tests/openapi_generic_multi_struct.rs
@@ -44,7 +44,7 @@ fn test_multi_generics_compile() {
     assert!(schemas.contains_key("One_Map"));
     assert!(schemas.contains_key("Two_List"));
     assert!(schemas.contains_key("GenericStruct-_One_Opt_One_-_Opt"));
-    macro_rules! component {
+    /*macro_rules! component {
         ($cn:expr) => {
             match schemas.get($cn) {
                 Some(ObjectOrReference::Object(s)) => s,
@@ -53,6 +53,7 @@ fn test_multi_generics_compile() {
             }
         };
     }
+    assert_eq!(&component!("One_Opt").one_of[0], ComponentOrInlineSchema::Component { name: Cow::Borrowed("One") });
     match &component!("One_Opt").one_of[0] {
         ObjectOrReference::Object(s) => {
             assert_eq!(s.ref_path, "#/components/schemas/One");
@@ -76,5 +77,5 @@ fn test_multi_generics_compile() {
             assert_eq!(s.schema_type, None);
         }
         None => panic!("Array component missing `items`"),
-    }
+    }*/
 }

--- a/tests/openapi_generic_multi_struct.rs
+++ b/tests/openapi_generic_multi_struct.rs
@@ -42,7 +42,7 @@ fn test_multi_generics_compile() {
     assert!(schemas.contains_key("GenericStruct-string_Opt_uinteger-"));
     assert!(schemas.contains_key("One_Opt"));
     assert!(schemas.contains_key("GenericStruct-One_Opt_One-_Opt"));
-    /*macro_rules! component {
+    macro_rules! component {
         ($cn:expr) => {
             match schemas.get($cn) {
                 Some(ObjectOrReference::Object(s)) => s,
@@ -51,29 +51,14 @@ fn test_multi_generics_compile() {
             }
         };
     }
-    assert_eq!(&component!("One_Opt").one_of[0], ComponentOrInlineSchema::Component { name: Cow::Borrowed("One") });
-    match &component!("One_Opt").one_of[0] {
-        ObjectOrReference::Object(s) => {
-            assert_eq!(s.ref_path, "#/components/schemas/One");
-            assert_eq!(s.schema_type, None);
+    assert_eq!(
+        &component!("GenericStruct-One_Opt_One-_Opt").nullable,
+        &Some(true)
+    );
+    assert_eq!(
+        &component!("GenericStruct-One_Opt_One-_Opt").properties["a"],
+        &ComponentOrInlineSchema::Component {
+            name: rt::Cow::Borrowed("One_Opt")
         }
-        ObjectOrReference::Ref { ref_path } => assert_eq!(ref_path, "#/components/schemas/One"),
-    }
-    match &component!("One_Map").additional_properties {
-        Some(ObjectOrReference::Object(s)) => {
-            assert_eq!(s.ref_path, "#/components/schemas/One");
-            assert_eq!(s.schema_type, None);
-        }
-        Some(ObjectOrReference::Ref { ref_path }) => {
-            assert_eq!(ref_path, "#/components/schemas/One")
-        }
-        None => panic!("Map component missing `additional_properties`"),
-    }
-    match &component!("Two_List").items {
-        Some(s) => {
-            assert_eq!(s.ref_path, "#/components/schemas/Two");
-            assert_eq!(s.schema_type, None);
-        }
-        None => panic!("Array component missing `items`"),
-    }*/
+    );
 }

--- a/tests/openapi_generic_multi_struct.rs
+++ b/tests/openapi_generic_multi_struct.rs
@@ -37,14 +37,12 @@ fn test_multi_generics_compile() {
             .chars()
             .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '-'))
     }
-    /*assert!(schemas.contains_key("One"));
+    assert!(schemas.contains_key("One"));
     assert!(schemas.contains_key("Two"));
-    assert!(schemas.contains_key("GenericStruct-_string_Opt_integer_-"));
+    assert!(schemas.contains_key("GenericStruct-string_Opt_integer-"));
     assert!(schemas.contains_key("One_Opt"));
-    assert!(schemas.contains_key("One_Map"));
-    assert!(schemas.contains_key("Two_List"));
-    assert!(schemas.contains_key("GenericStruct-_One_Opt_One_-_Opt"));
-    macro_rules! component {
+    assert!(schemas.contains_key("GenericStruct-One_Opt_One-_Opt"));
+    /*macro_rules! component {
         ($cn:expr) => {
             match schemas.get($cn) {
                 Some(ObjectOrReference::Object(s)) => s,

--- a/tests/openapi_multi_struct.rs
+++ b/tests/openapi_multi_struct.rs
@@ -37,7 +37,7 @@ fn description() {
     assert!(schemas.contains_key("Two"));
     assert!(schemas.contains_key("Three"));
     assert!(schemas.contains_key("One_Opt"));
-    assert!(schemas.contains_key("One_Opt_List"));
+    assert!(!schemas.contains_key("One_Opt_List"));
     assert!(!schemas.contains_key("One_List"));
     assert!(!schemas.contains_key("Two_List"));
     assert!(!schemas.contains_key("Three_List"));

--- a/tests/openapi_required.rs
+++ b/tests/openapi_required.rs
@@ -72,7 +72,7 @@ fn test_enum() {
     println!("{}", serde_yaml::to_string(&schema).unwrap());
     for variant in &schema.one_of {
         match variant {
-            openapi::ObjectOrReference::Object(vs) => {
+            openapi::ComponentOrInlineSchema::Inline(vs) => {
                 if vs.properties.contains_key(&Cow::Borrowed("afield")) {
                     assert!(vs.required.contains(&Cow::Borrowed("afield")));
                 }

--- a/tests/openapi_required.rs
+++ b/tests/openapi_required.rs
@@ -51,7 +51,7 @@ enum TestEnum {
 }
 
 #[get("/")]
-fn test_enum_r(_: Query<TestEnum>) -> String {
+fn test_enum_r(_: Json<TestEnum>) -> String {
     String::new()
 }
 

--- a/tests/openapi_response.rs
+++ b/tests/openapi_response.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 enum Error {}
 
 impl openapi::ResponseEntity for Error {
-    fn describe_responses() -> openapi::Responses {
+    fn describe_responses(_: &mut openapi::ComponentDescriptor) -> openapi::Responses {
         let mut map = IndexMap::new();
 
         map.insert(

--- a/tests/openapi_result_extagged.rs
+++ b/tests/openapi_result_extagged.rs
@@ -34,18 +34,18 @@ fn description() {
     macro_rules! object {
         ($o:expr) => {
             match $o {
-                openapi::ObjectOrReference::Object(s) => s,
+                openapi::ComponentOrInlineSchema::Inline(s) => s,
                 _ => panic!("Expected object, not reference"),
             }
         };
     }
-    let res = &component!("IHazResult").properties["result"];
+    let res = object!(&component!("IHazResult").properties["result"]);
     assert_eq!(
         object!(&res.one_of[0]).schema_type,
         Some(openapi::Type::Object)
     );
     assert_eq!(
-        object!(&res.one_of[0]).properties["Ok"].schema_type,
+        object!(&object!(&res.one_of[0]).properties["Ok"]).schema_type,
         Some(openapi::Type::Integer)
     );
     assert_eq!(
@@ -53,7 +53,7 @@ fn description() {
         Some(openapi::Type::Object)
     );
     assert_eq!(
-        object!(&res.one_of[1]).properties["Err"].schema_type,
+        object!(&object!(&res.one_of[1]).properties["Err"]).schema_type,
         Some(openapi::Type::String)
     );
 }

--- a/tests/openapi_skip.rs
+++ b/tests/openapi_skip.rs
@@ -30,20 +30,24 @@ fn test_skip() {
         rweb::openapi::ObjectOrReference::Object(s) => s,
         _ => panic!(),
     };
+    macro_rules! unpack {
+        ($opt:expr) => {
+            $opt.unwrap().unwrap().unwrap()
+        };
+    }
+    macro_rules! prop {
+        ($prop:expr) => {
+            unpack!(whence.properties.get($prop))
+        };
+    }
     assert!(whence.properties.contains_key("always"));
     assert!(whence.properties.contains_key("only_yeet"));
     assert!(whence.properties.contains_key("only_take"));
     assert!(!whence.properties.contains_key("nevah"));
-    assert_eq!(whence.properties.get("always").unwrap().read_only, None);
-    assert_eq!(whence.properties.get("always").unwrap().write_only, None);
-    assert_eq!(
-        whence.properties.get("only_yeet").unwrap().read_only,
-        Some(true)
-    );
-    assert_eq!(whence.properties.get("only_yeet").unwrap().write_only, None);
-    assert_eq!(whence.properties.get("only_take").unwrap().read_only, None);
-    assert_eq!(
-        whence.properties.get("only_take").unwrap().write_only,
-        Some(true)
-    );
+    assert_eq!(prop!("always").read_only, None);
+    assert_eq!(prop!("always").write_only, None);
+    assert_eq!(prop!("only_yeet").read_only, Some(true));
+    assert_eq!(prop!("only_yeet").write_only, None);
+    assert_eq!(prop!("only_take").read_only, None);
+    assert_eq!(prop!("only_take").write_only, Some(true));
 }


### PR DESCRIPTION
This PR goes hand-in-hand with kdy1/openapi#2 (merging just one _will break_).

## Improvements

This PR addresses the components, properly - the 2 descriptor methods from `Entity` are merged into just one, `describe(comp_d)` which describes the entity itself and any components it, or its sub-schemas require, using `ComponentDescriptor`. As an added bonus, components are now described just once.

To address proper generic component name resolution, `Entity::type_name` has been added to compute at runtime the (unique) name of the type. This drops the requirement of having to generate a stack of unused components to just to resolve the generic-parametrized names (`One` and `Two<Vec<Vec<One>>` can be components, without needing `Vec<One>` or `Vec<Vec<One>>` as components).

Finally, unsigned integers set `minimum: 0` and use a different `type_name` of `uinteger`.

¯\\\_(ツ)\_/¯

## Issues uncovered

The logical separation of `Schema` into `ComponentOrInlineSchema` revealed that serde read/write only does not apply to components (correctly). This PR does not attempt to deal with that issue.

## Merge order
1. Merge kdy1/openapi#2
2. Update cargo dep for `rweb-openapi` _on this PR/branch_, and move out of draft
3. Merge this
