### PR TITLE
Fix derive Entity/Schema generate non-compliant component descibers

### DIFF
--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -516,23 +516,33 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
     block.stmts.push(Stmt::Expr(
         if component.is_some() {
             q!(Vars { desc, fields }, {
-                comp_d.describe_component(&Self::type_name(), |comp_d| rweb::openapi::Schema {
+                rweb::openapi::Schema {
                     fields,
                     description: rweb::rt::Cow::Borrowed(desc),
                     ..rweb::rt::Default::default()
-                })
+                }
             })
         } else {
             q!(Vars { desc, fields }, {
-                rweb::openapi::ComponentOrInlineSchema::Inline(rweb::openapi::Schema {
+                rweb::openapi::Schema {
                     fields,
                     description: rweb::rt::Cow::Borrowed(desc),
                     ..rweb::rt::Default::default()
-                })
+                }
             })
         }
         .parse(),
     ));
+    let block: Expr = if component.is_some() {
+        q!(Vars { block }, {
+            comp_d.describe_component(&Self::type_name(), |comp_d| block)
+        })
+    } else {
+        q!(Vars { block }, {
+            rweb::openapi::ComponentOrInlineSchema::Inline(block)
+        })
+    }
+    .parse();
 
     let typename = component.clone().unwrap_or_else(|| ident.to_string());
     let typename: Expr = if generics.params.is_empty() {

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -514,23 +514,13 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
     }
 
     block.stmts.push(Stmt::Expr(
-        if component.is_some() {
-            q!(Vars { desc, fields }, {
-                rweb::openapi::Schema {
-                    fields,
-                    description: rweb::rt::Cow::Borrowed(desc),
-                    ..rweb::rt::Default::default()
-                }
-            })
-        } else {
-            q!(Vars { desc, fields }, {
-                rweb::openapi::Schema {
-                    fields,
-                    description: rweb::rt::Cow::Borrowed(desc),
-                    ..rweb::rt::Default::default()
-                }
-            })
-        }
+        q!(Vars { desc, fields }, {
+            rweb::openapi::Schema {
+                fields,
+                description: rweb::rt::Cow::Borrowed(desc),
+                ..rweb::rt::Default::default()
+            }
+        })
         .parse(),
     ));
     let block: Expr = if component.is_some() {

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -727,8 +727,7 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
                 rweb::openapi::ComponentOrInlineSchema::Inline(block)
             })
         }
-    })
-    .parse();
+    }.parse());
 
     let typename = component.clone().unwrap_or_else(|| ident.to_string());
     let typename: Expr = if generics.params.is_empty() {

--- a/tests/openapi_components_recursive.rs
+++ b/tests/openapi_components_recursive.rs
@@ -1,0 +1,42 @@
+#![cfg(feature = "openapi")]
+
+use rweb::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Schema)]
+#[schema(component = "Bar")]
+pub struct Bar {
+    pub foo: Box<Foo>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Schema)]
+pub struct NotAComponent {
+    pub foo: Box<Foo>,
+    pub bar: Vec<Bar>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Schema)]
+#[schema(component = "Foo")]
+pub struct Foo {
+    pub interim: Option<Box<NotAComponent>>,
+}
+
+#[get("/")]
+fn test_r(_: Json<Foo>) -> String {
+    String::new()
+}
+
+#[test]
+fn test_component_recursion_compile() {
+    let (spec, _) = openapi::spec().build(|| test_r());
+    let schemas = &spec.components.as_ref().unwrap().schemas;
+    println!("{}", serde_yaml::to_string(&schemas).unwrap());
+    for (name, _) in schemas {
+        assert!(name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '-'))
+    }
+    assert!(schemas.contains_key("Foo"));
+    assert!(schemas.contains_key("Bar"));
+    assert!(!schemas.contains_key("NotAComponent"));
+}


### PR DESCRIPTION
The code describing fields of the component was being placed outside (before) the descriptor called from the `describe_component`, which resulted in stack overflow without `describe_component` ever being called.

Provided test case, by @johnchildren.

Closes #97, _for [named] components_.