### PR TITLE
Support all 4 serde enum representations

### DIFF
--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -20,9 +20,7 @@ fn get_serde_meta_attrs<'a>(attrs: &'a [Attribute]) -> impl Iterator<Item = Meta
         .iter()
         .filter_map(|attr| {
             if attr.path.is_ident("serde") {
-                parse2::<Paren<Meta>>(attr.tokens.clone())
-                    .map(|p| p.inner)
-                    .ok()
+                attr.parse_meta().ok()
             } else {
                 None
             }

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -505,25 +505,25 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
                     .collect();
 
                 match ett {
-					EnumTagType::External => {
-						fields.push(q!(Vars { exprs }, { enum_values: vec![exprs] }).parse());
-						fields.push(q!({ schema_type: Some(rweb::openapi::Type::String) }).parse());
-					}
-					EnumTagType::Internal { tag } | EnumTagType::Adjacent { tag, .. } => {
-						fields.push(q!({ schema_type: Some(rweb::openapi::Type::Object) }).parse());
-						fields.push(q!(Vars { exprs, tag: tag.as_str() }, {
-							properties: rweb::rt::indexmap![rweb::rt::Cow::Borrowed(tag) => rweb::openapi::ComponentOrInlineSchema::Inline(rweb::openapi::Schema {
-								schema_type: Some(rweb::openapi::Type::String),
-								enum_values: vec![exprs],
-								..rweb::rt::Default::default()
-							})]
-						}).parse());
-						fields.push(q!(Vars { tag }, {
-							required: vec![rweb::rt::Cow::Borrowed(tag)]
-						}).parse());
-					}
-					EnumTagType::None => panic!("Schema generation for C-Like enums with untagged representation is not supported")
-				}
+                    EnumTagType::External => {
+                        fields.push(q!(Vars { exprs }, { enum_values: vec![exprs] }).parse());
+                        fields.push(q!({ schema_type: Some(rweb::openapi::Type::String) }).parse());
+                    }
+                    EnumTagType::Internal { tag } | EnumTagType::Adjacent { tag, .. } => {
+                        fields.push(q!({ schema_type: Some(rweb::openapi::Type::Object) }).parse());
+                        fields.push(q!(Vars { exprs, tag: tag.as_str() }, {
+                            properties: rweb::rt::indexmap![rweb::rt::Cow::Borrowed(tag) => rweb::openapi::ComponentOrInlineSchema::Inline(rweb::openapi::Schema {
+                                schema_type: Some(rweb::openapi::Type::String),
+                                enum_values: vec![exprs],
+                                ..rweb::rt::Default::default()
+                            })]
+                        }).parse());
+                        fields.push(q!(Vars { tag }, {
+                            required: vec![rweb::rt::Cow::Borrowed(tag)]
+                        }).parse());
+                    }
+                    EnumTagType::None => panic!("Schema generation for C-Like enums with untagged representation is not supported")
+                }
             } else {
                 let variants: Vec<(String, Option<Expr>)> = data.variants.iter().filter_map(|v| {
                     let name = get_rename(&v.attrs).unwrap_or_else(|| get_rename_all(&attrs).apply_to_variant(&v.ident.to_string()));

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -485,7 +485,7 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
                 .iter()
                 .all(|variant| variant.fields.is_empty())
             {
-                // c-like enums
+                // unit-like enums
 
                 let exprs: Punctuated<Expr, Token![,]> = data
                     .variants
@@ -522,7 +522,7 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
                             required: vec![rweb::rt::Cow::Borrowed(tag)]
                         }).parse());
                     }
-                    EnumTagType::None => panic!("Schema generation for C-Like enums with untagged representation is not supported")
+                    EnumTagType::None => panic!("Schema generation for unit-like enums with untagged representation is not supported")
                 }
             } else {
                 let variants: Vec<(String, Option<Expr>)> = data.variants.iter().filter_map(|v| {

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -1,17 +1,17 @@
 use crate::{
     openapi::case::RenameRule,
-    parse::{Delimited, KeyValue, Paren},
+    parse::{Delimited, Paren},
     route::EqStr,
     util::ItemImplExt,
 };
 use pmutil::{q, ToTokensExt};
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::TokenStream;
 use syn::{
     parse2,
     punctuated::{Pair, Punctuated},
     Attribute, Block, Data, DeriveInput, Expr, Field, FieldValue, Fields, GenericParam, ItemImpl,
-    Lit, LitStr, Meta, MetaList, MetaNameValue, NestedMeta, Stmt, Token, TraitBound,
-    TraitBoundModifier, TypeParamBound,
+    Lit, Meta, MetaList, MetaNameValue, NestedMeta, Stmt, Token, TraitBound, TraitBoundModifier,
+    TypeParamBound,
 };
 
 /// Extracts all `#[serde(..)]` attributes and flattens `Meta::List`s.

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -499,6 +499,7 @@ pub fn derive_schema(input: DeriveInput) -> TokenStream {
                 Fields::Unnamed(..) => {
                     panic!("Schema generation for tuple structs is currently not supported")
                 }
+                Fields::Unit => fields.push(q!({ nullable: Some(true) }).parse()),
             }
 
             fields.push(q!({ schema_type: Some(rweb::openapi::Type::Object) }).parse());

--- a/macros/src/openapi/derive.rs
+++ b/macros/src/openapi/derive.rs
@@ -178,7 +178,7 @@ Correct usage: #[schema(description = \"foo\", example = \"bar\")]",
     };
 }
 
-fn extract_example(attrs: &mut Vec<Attribute>) -> Option<TokenStream> {
+fn extract_example(attrs: &Vec<Attribute>) -> Option<TokenStream> {
     let mut v = None;
 
     let mut process_nv = |n: syn::MetaNameValue| {
@@ -245,7 +245,7 @@ fn extract_example(attrs: &mut Vec<Attribute>) -> Option<TokenStream> {
     }
 }
 
-fn extract_doc(attrs: &mut Vec<Attribute>) -> String {
+fn extract_doc(attrs: &Vec<Attribute>) -> String {
     let mut doc = None;
     let mut comments = String::new();
 
@@ -299,11 +299,11 @@ fn extract_doc(attrs: &mut Vec<Attribute>) -> String {
     }
 }
 
-fn handle_field(type_attrs: &[Attribute], f: &mut Field) -> Stmt {
+fn handle_field(type_attrs: &[Attribute], f: &Field) -> Stmt {
     let name_str = field_name(type_attrs, &*f);
 
-    let desc = extract_doc(&mut f.attrs);
-    let example_v = extract_example(&mut f.attrs);
+    let desc = extract_doc(&f.attrs);
+    let example_v = extract_example(&f.attrs);
     let (skip_ser, skip_de) = get_skip_mode(&f.attrs);
 
     // We don't require it to be `Entity`
@@ -352,7 +352,7 @@ fn handle_field(type_attrs: &[Attribute], f: &mut Field) -> Stmt {
     .parse()
 }
 
-fn handle_fields(type_attrs: &[Attribute], fields: &mut Fields) -> Block {
+fn handle_fields(type_attrs: &[Attribute], fields: &Fields) -> Block {
     // Properties
     let mut block: Block = q!({ {} }).parse();
     block.stmts.push(

--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -203,6 +203,7 @@ impl Entity for () {
     fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
         ComponentOrInlineSchema::Inline(Schema {
             schema_type: Some(Type::Object),
+            nullable: Some(true),
             ..Default::default()
         })
     }

--- a/tests/openapi_enum.rs
+++ b/tests/openapi_enum.rs
@@ -4,19 +4,53 @@ use rweb::*;
 use serde::{Deserialize, Serialize};
 use serde_yaml;
 
-#[get("/")]
-fn index(_: Json<Enum>) -> String {
-    String::new()
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "EExttagged")]
+enum EExttagged {
+    A(String),
+    B(usize),
+    Stru { field: String },
+    Plain,
 }
 
 #[derive(Debug, Serialize, Deserialize, Schema)]
-enum Enum {
+#[serde(tag = "tag")]
+#[schema(component = "EInttagged")]
+enum EInttagged {
+    Stru { field: String },
+    Plain,
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[serde(tag = "tag", content = "content")]
+#[schema(component = "EAdjtagged")]
+enum EAdjtagged {
     A(String),
     B(usize),
-    Ref {
-        /// Reference-foo-bar-baz
-        ref_path: String,
-    },
+    Stru { field: String },
+    Plain,
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[serde(untagged)]
+#[schema(component = "EUntagged")]
+enum EUntagged {
+    A(String),
+    B(usize),
+    Stru { field: String },
+}
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+struct Enums {
+    ext: EExttagged,
+    adj: EAdjtagged,
+    int: EInttagged,
+    unt: EUntagged,
+}
+
+#[get("/")]
+fn index(_: Json<Enums>) -> String {
+    String::new()
 }
 
 #[test]
@@ -26,11 +60,201 @@ fn description() {
         index()
     });
 
-    assert!(spec.paths.get("/").is_some());
-    assert!(spec.paths.get("/").unwrap().get.is_some());
-
-    let yaml = serde_yaml::to_string(&spec).unwrap();
-    println!("{}", yaml);
-
-    assert!(yaml.contains("Reference-foo-bar-baz"));
+    println!("{}", serde_yaml::to_string(&spec).unwrap());
+    let schemas = &spec.components.as_ref().unwrap().schemas;
+    macro_rules! component {
+        ($cn:expr) => {
+            match schemas.get($cn) {
+                Some(openapi::ObjectOrReference::Object(s)) => s,
+                Some(..) => panic!("Component schema can't be a reference"),
+                None => panic!("No component schema for {}", $cn),
+            }
+        };
+    }
+    println!("{}", serde_yaml::to_string(&EExttagged::B(55)).unwrap());
+    println!("{}", serde_yaml::to_string(&EExttagged::Plain).unwrap());
+    let schema = component!("EExttagged");
+    assert_eq!(schema.one_of.len(), 4);
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().schema_type,
+        Some(openapi::Type::Object)
+    );
+    assert_eq!(schema.one_of[0].unwrap().unwrap().required, vec!["A"]);
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().properties["A"]
+            .unwrap()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::String)
+    );
+    assert_eq!(
+        schema.one_of[1].unwrap().unwrap().schema_type,
+        Some(openapi::Type::Object)
+    );
+    assert_eq!(schema.one_of[1].unwrap().unwrap().required, vec!["B"]);
+    assert_eq!(
+        schema.one_of[1].unwrap().unwrap().properties["B"]
+            .unwrap()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::Integer)
+    );
+    assert_eq!(
+        schema.one_of[2].unwrap().unwrap().schema_type,
+        Some(openapi::Type::Object)
+    );
+    assert_eq!(schema.one_of[2].unwrap().unwrap().required, vec!["Stru"]);
+    assert_eq!(
+        schema.one_of[2].unwrap().unwrap().properties["Stru"]
+            .unwrap()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::Object)
+    );
+    assert_eq!(
+        schema.one_of[3].unwrap().unwrap().schema_type,
+        Some(openapi::Type::String)
+    );
+    assert_eq!(
+        schema.one_of[3].unwrap().unwrap().enum_values,
+        vec!["Plain"]
+    );
+    let schema = component!("EInttagged");
+    assert_eq!(schema.one_of.len(), 2);
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().schema_type,
+        Some(openapi::Type::Object)
+    );
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().required,
+        vec!["field", "tag"]
+    );
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().properties["field"]
+            .unwrap()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::String)
+    );
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().properties["tag"]
+            .unwrap()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::String)
+    );
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().properties["tag"]
+            .unwrap()
+            .unwrap()
+            .enum_values,
+        vec!["Stru"]
+    );
+    assert_eq!(
+        schema.one_of[1].unwrap().unwrap().schema_type,
+        Some(openapi::Type::Object)
+    );
+    assert_eq!(schema.one_of[1].unwrap().unwrap().required, vec!["tag"]);
+    assert_eq!(
+        schema.one_of[1].unwrap().unwrap().properties["tag"]
+            .unwrap()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::String)
+    );
+    assert_eq!(
+        schema.one_of[1].unwrap().unwrap().properties["tag"]
+            .unwrap()
+            .unwrap()
+            .enum_values,
+        vec!["Plain"]
+    );
+    let schema = component!("EAdjtagged");
+    assert_eq!(schema.one_of.len(), 4);
+    for s in &schema.one_of {
+        assert_eq!(s.unwrap().unwrap().schema_type, Some(openapi::Type::Object));
+        assert_eq!(
+            s.unwrap().unwrap().properties["tag"]
+                .unwrap()
+                .unwrap()
+                .schema_type,
+            Some(openapi::Type::String)
+        );
+    }
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().required,
+        vec!["tag", "content"]
+    );
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().properties["tag"]
+            .unwrap()
+            .unwrap()
+            .enum_values,
+        vec!["A"]
+    );
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().properties["content"]
+            .unwrap()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::String)
+    );
+    assert_eq!(
+        schema.one_of[1].unwrap().unwrap().required,
+        vec!["tag", "content"]
+    );
+    assert_eq!(
+        schema.one_of[1].unwrap().unwrap().properties["tag"]
+            .unwrap()
+            .unwrap()
+            .enum_values,
+        vec!["B"]
+    );
+    assert_eq!(
+        schema.one_of[1].unwrap().unwrap().properties["content"]
+            .unwrap()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::Integer)
+    );
+    assert_eq!(
+        schema.one_of[2].unwrap().unwrap().required,
+        vec!["tag", "content"]
+    );
+    assert_eq!(
+        schema.one_of[2].unwrap().unwrap().properties["tag"]
+            .unwrap()
+            .unwrap()
+            .enum_values,
+        vec!["Stru"]
+    );
+    assert_eq!(
+        schema.one_of[2].unwrap().unwrap().properties["content"]
+            .unwrap()
+            .unwrap()
+            .schema_type,
+        Some(openapi::Type::Object)
+    );
+    assert_eq!(schema.one_of[3].unwrap().unwrap().required, vec!["tag"]);
+    assert_eq!(
+        schema.one_of[3].unwrap().unwrap().properties["tag"]
+            .unwrap()
+            .unwrap()
+            .enum_values,
+        vec!["Plain"]
+    );
+    let schema = component!("EUntagged");
+    assert_eq!(schema.one_of.len(), 3);
+    assert_eq!(
+        schema.one_of[0].unwrap().unwrap().schema_type,
+        Some(openapi::Type::String)
+    );
+    assert_eq!(
+        schema.one_of[1].unwrap().unwrap().schema_type,
+        Some(openapi::Type::Integer)
+    );
+    assert_eq!(
+        schema.one_of[2].unwrap().unwrap().schema_type,
+        Some(openapi::Type::Object)
+    );
 }

--- a/tests/openapi_multi_struct.rs
+++ b/tests/openapi_multi_struct.rs
@@ -20,8 +20,19 @@ pub struct Three {
     list_of_opt_of_one: Vec<Option<One>>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Schema)]
+#[schema(component = "Wrapper")]
+pub struct Wrapper(Three);
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+struct Relevant {
+    one: One,
+    three: Three,
+    wrapper: Wrapper,
+}
+
 #[get("/")]
-fn index(_: Query<One>, _: Json<Three>) -> String {
+fn index(_: Query<Relevant>) -> String {
     String::new()
 }
 
@@ -43,4 +54,5 @@ fn description() {
     assert!(!schemas.contains_key("Three_List"));
     assert!(!schemas.contains_key("Two_Opt"));
     assert!(!schemas.contains_key("Three_Opt"));
+    assert!(schemas.contains_key("Wrapper"));
 }

--- a/tests/openapi_multi_struct.rs
+++ b/tests/openapi_multi_struct.rs
@@ -18,17 +18,21 @@ pub struct Two {}
 pub struct Three {
     two: Two,
     list_of_opt_of_one: Vec<Option<One>>,
+    wrapper: Wrapper,
+    unit: Unit,
 }
 
 #[derive(Debug, Serialize, Deserialize, Schema)]
 #[schema(component = "Wrapper")]
-pub struct Wrapper(Three);
+pub struct Wrapper(One);
+
+#[derive(Debug, Serialize, Deserialize, Schema)]
+pub struct Unit;
 
 #[derive(Debug, Serialize, Deserialize, Schema)]
 struct Relevant {
     one: One,
     three: Three,
-    wrapper: Wrapper,
 }
 
 #[get("/")]
@@ -44,6 +48,15 @@ fn description() {
     });
     let schemas = &spec.components.as_ref().unwrap().schemas;
     println!("{}", serde_yaml::to_string(&schemas).unwrap());
+    macro_rules! component {
+        ($cn:expr) => {
+            match schemas.get($cn) {
+                Some(openapi::ObjectOrReference::Object(s)) => s,
+                Some(..) => panic!("Component schema can't be a reference"),
+                None => panic!("No component schema for {}", $cn),
+            }
+        };
+    }
     assert!(schemas.contains_key("One"));
     assert!(schemas.contains_key("Two"));
     assert!(schemas.contains_key("Three"));
@@ -54,5 +67,21 @@ fn description() {
     assert!(!schemas.contains_key("Three_List"));
     assert!(!schemas.contains_key("Two_Opt"));
     assert!(!schemas.contains_key("Three_Opt"));
-    assert!(schemas.contains_key("Wrapper"));
+    assert!(!schemas.contains_key("Wrapper"));
+    assert!(!schemas.contains_key("Unit"));
+    let schema = component!("Three");
+    assert_eq!(
+        schema.properties["wrapper"],
+        openapi::ComponentOrInlineSchema::Component {
+            name: std::borrow::Cow::Borrowed("One")
+        }
+    );
+    assert_eq!(
+        schema.properties["unit"].unwrap().unwrap().schema_type,
+        Some(openapi::Type::Object)
+    );
+    assert_eq!(
+        schema.properties["unit"].unwrap().unwrap().nullable,
+        Some(true)
+    );
 }

--- a/tests/openapi_rename.rs
+++ b/tests/openapi_rename.rs
@@ -63,7 +63,7 @@ fn struct_rename_all() {
     println!("{}", yaml);
 
     assert!(yaml.contains("dataMsg"));
-    assert!(yaml.contains("DATA2_MESSAGE"));
+    assert!(yaml.contains("DATA2_MSG"));
 }
 
 #[test]

--- a/tests/openapi_rename.rs
+++ b/tests/openapi_rename.rs
@@ -33,14 +33,22 @@ fn struct_field() {
 #[test]
 fn struct_rename_all() {
     #[derive(Debug, Serialize, Deserialize, Schema)]
+    #[serde(deny_unknown_fields)]
     #[serde(rename_all = "camelCase")]
     struct Data {
         data_msg: String,
     }
+    #[derive(Debug, Serialize, Deserialize, Schema)]
+    #[serde(deny_unknown_fields, rename_all = "SCREAMING_SNAKE_CASE")]
+    struct Data2 {
+        data2_msg: String,
+    }
 
     #[get("/")]
-    fn index(_: Query<Data>) -> String {
-        String::new()
+    fn index(_: Query<Data>) -> Json<Data2> {
+        Json::from(Data2 {
+            data2_msg: String::new(),
+        })
     }
 
     let (spec, _) = openapi::spec().build(|| {
@@ -55,6 +63,7 @@ fn struct_rename_all() {
     println!("{}", yaml);
 
     assert!(yaml.contains("dataMsg"));
+    assert!(yaml.contains("DATA2_MESSAGE"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #95.

Adds detection and support for different serde enum representations.

Current implementation does so _without_ the use of `discriminator` - which is only applicable to internally and adjacently tagged representations anyway - since as per [spec](https://spec.openapis.org/oas/v3.1.0#discriminator-object),
> When using the discriminator, _inline_ schemas will not be considered.

[and](https://spec.openapis.org/oas/v3.1.0#composition-and-inheritance-polymorphism)

> ... inline schema definitions, which do not have a given id, _cannot_ be used in polymorphism.

It is thus either necessary to
- ignore `discriminator` and `propertyName` polymorphism, and provide `oneOf` inline definitions as-is (injecting repr tags into the schemas)
- require that concerned enums be components to generate a suffixed component per each variant for use with proper OpenAPI 3.1 polymorphism

It is possible to provide both (i.e. iff the enum is a component, use polymorphism, otherwise default to plain `oneOf`), however here provided implementation _always_ uses the first approach.

Footnote: schema generation for unit-like enums (or unit variants) for `untagged` representation is not supported.

PS: Along the way, this PR improves `serde` attrbutes parsing which fixes #99; additionally it provides
- support for unit structs (and marks `()` and such objects as `nullable`)
- support for newtype structs (akin to newtype enum variants)
- proper ~~error message~~ panic for tuple structs (neither tuple structs nor tuple enum variants are yet supported) 