### PR TITLE
feat(rweb): Implement Entity for Ipv4Addr/Ipv6Addr

### DIFF
--- a/src/openapi/entity.rs
+++ b/src/openapi/entity.rs
@@ -711,6 +711,34 @@ impl ResponseEntity for dyn Reply {
     }
 }
 
+impl Entity for std::net::Ipv4Addr {
+    fn type_name() -> Cow<'static, str> {
+        Cow::Borrowed("ipv4")
+    }
+
+    fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        ComponentOrInlineSchema::Inline(Schema {
+            schema_type: Some(Type::String),
+            format: Self::type_name(),
+            ..Default::default()
+        })
+    }
+}
+
+impl Entity for std::net::Ipv6Addr {
+    fn type_name() -> Cow<'static, str> {
+        Cow::Borrowed("ipv6")
+    }
+
+    fn describe(_: &mut ComponentDescriptor) -> ComponentOrInlineSchema {
+        ComponentOrInlineSchema::Inline(Schema {
+            schema_type: Some(Type::String),
+            format: Self::type_name(),
+            ..Default::default()
+        })
+    }
+}
+
 #[cfg(feature = "uuid")]
 impl Entity for uuid::Uuid {
     fn type_name() -> Cow<'static, str> {


### PR DESCRIPTION
Hey.

I've added an Entity implementation for `std::net::{Ipv4Addr, Ipv6Addr}` with the format `ipv4` and `ipv6`, respectively.

The above format names are mentioned in [Swagger Data Type String Formats](https://swagger.io/docs/specification/data-models/data-types/#string).

EDIT:  I've noticed this project is not formatted according to what `cargo fmt`/rustfmt wants. Is this intended?